### PR TITLE
Add flag to respect $SHELL, add short-hand for disable-status and tests

### DIFF
--- a/src/invoke_toolkit/config/config.py
+++ b/src/invoke_toolkit/config/config.py
@@ -94,6 +94,7 @@ class ToolkitConfig(Config):
         ret["runners"]["local"] = NoStdoutRunner
         ret["run"]["echo_format"] = "[bold]{command}[/bold]"
         ret["disable_status"] = False
+        ret["init_shell"] = False
 
         return ret
 

--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -7,6 +7,7 @@ It allows three classes to be parametrized: Loader, Config and Executor
 __all__ = ["ToolkitProgram"]
 
 import inspect
+import os
 import re
 import sys
 from importlib import metadata
@@ -181,6 +182,18 @@ class ToolkitProgram(Program):
             debug("Disabling status context manager via CLI flag")
             self.config["disable_status"] = True
 
+        # Update config with init_shell flag from CLI
+        if self.args["init_shell"].value:
+            debug("Initializing shell for runner via CLI flag")
+            self.config["init_shell"] = True
+            # Set shell from $SHELL environment variable
+            shell = os.environ.get("SHELL")
+            if shell:
+                debug(f"Setting shell to {shell} from $SHELL environment variable")
+                self.config["run"]["shell"] = shell
+            else:
+                debug("$SHELL environment variable not set, using default shell")
+
         # Set interpreter bytecode-writing flag
         sys.dont_write_bytecode = not self.args["write-pyc"].value
 
@@ -310,10 +323,16 @@ class ToolkitProgram(Program):
                 "redactbing both for [green]stdout[/green] and [yellow]stderr[/yellow]",
             ),
             Argument(
-                names=("disable_status",),
+                names=("disable_status", "ds"),
                 kind=bool,
                 default=False,
                 help="Disables the rich status context manager for debugging (useful when debugging breakpoints or using REPL)",
+            ),
+            Argument(
+                names=("init_shell",),
+                kind=bool,
+                default=False,
+                help="Initialize the shell for the runner using the $SHELL environment variable",
             ),
         ]
         args.extend(toolkit_program_arguments)

--- a/tests/test_disable_status_cli.py
+++ b/tests/test_disable_status_cli.py
@@ -6,9 +6,9 @@ from typing import cast
 
 import pytest
 
-from invoke_toolkit import task, Context
-from invoke_toolkit.testing import TestingToolkitProgram
+from invoke_toolkit import Context, task
 from invoke_toolkit.collections import ToolkitCollection
+from invoke_toolkit.testing import TestingToolkitProgram
 
 
 @task()
@@ -123,3 +123,105 @@ def test_disable_status_config_value_set(suppress_stderr_logging):
 
     # Run with --disable-status flag
     p.run(["", "--disable-status", "check-config-task"], exit=False)
+
+
+def test_disable_status_shorthand_flag(capsys, suppress_stderr_logging):
+    """Test that --ds shorthand flag works for --disable-status"""
+    coll = ToolkitCollection(status_task)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+
+    # Run with --ds shorthand flag
+    p.run(["", "--ds", "status-task"], exit=False)
+    captured = capsys.readouterr()
+    out = captured.out
+
+    # The output should still contain the print output
+    assert "hello from status" in out, f"Expected 'hello from status' in output:\n{out}"
+
+
+def test_disable_status_shorthand_in_help(capsys, suppress_stderr_logging):
+    """Test that --ds shorthand appears in help output."""
+    coll = ToolkitCollection(status_task)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+    p.run(["", "--help"], exit=False)
+    out, _err = capsys.readouterr()
+
+    # The help text should contain the shorthand
+    assert "--ds" in out, f"Expected '--ds' in output:\n{out}"
+
+
+def test_disable_status_env_variable(monkeypatch, capsys, suppress_stderr_logging):
+    """Test that INVOKE_DISABLE_STATUS environment variable works"""
+    # Set the environment variable
+    monkeypatch.setenv("INVOKE_DISABLE_STATUS", "1")
+
+    @task()
+    def status_task_env(ctx: Context):
+        """A task that uses the status context manager."""
+        with ctx.status("Processing..."):
+            ctx.print("hello from env status")
+
+    coll = ToolkitCollection(status_task_env)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+
+    # Run without the flag - the environment variable should disable status
+    p.run(["", "status-task-env"], exit=False)
+    captured = capsys.readouterr()
+    out = captured.out
+
+    # The output should contain the print output
+    assert "hello from env status" in out, (
+        f"Expected 'hello from env status' in output:\n{out}"
+    )
+
+
+def test_init_shell_flag_sets_shell(suppress_stderr_logging):
+    """Test that --init-shell flag sets shell from $SHELL environment variable"""
+
+    @task()
+    def check_shell_config(ctx: Context):
+        """A task that checks if shell is set in config."""
+        # Check that the config has run.shell set
+        shell = ctx.config.get("run", {}).get("shell")
+        assert shell is not None, "shell should be set in run config"
+
+    coll = ToolkitCollection(check_shell_config)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+
+    # Run with --init-shell flag
+    p.run(["", "--init-shell", "check-shell-config"], exit=False)
+
+
+def test_init_shell_flag_uses_shell_env(monkeypatch, suppress_stderr_logging):
+    """Test that --init-shell flag uses the $SHELL environment variable"""
+    # Set a custom shell environment variable
+    custom_shell = "/custom/bin/zsh"
+    monkeypatch.setenv("SHELL", custom_shell)
+
+    @task()
+    def check_shell_value(ctx: Context):
+        """A task that checks if shell is set correctly."""
+        shell = ctx.config.get("run", {}).get("shell")
+        assert shell == custom_shell, (
+            f"Expected shell to be {custom_shell}, got {shell}"
+        )
+
+    coll = ToolkitCollection(check_shell_value)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+
+    # Run with --init-shell flag
+    p.run(["", "--init-shell", "check-shell-value"], exit=False)
+
+
+def test_init_shell_flag_shows_in_help(capsys, suppress_stderr_logging):
+    """Test that --init-shell flag appears in help output."""
+    coll = ToolkitCollection(status_task)
+    p = TestingToolkitProgram(namespace=coll, binary="test")
+    p.run(["", "--help"], exit=False)
+    out, _err = capsys.readouterr()
+
+    # The help text should contain the init-shell flag
+    assert "--init-shell" in out, f"Expected '--init-shell' in output:\n{out}"
+    assert "SHELL" in out or "shell" in out.lower(), (
+        f"Expected reference to shell in output:\n{out}"
+    )


### PR DESCRIPTION
- Add shorthand '-ds' for '--disable-status' flag
- Add '--init-shell' flag to initialize shell from $SHELL environment variable
- Verify INVOKE_DISABLE_STATUS environment variable support (already works via PyInvoke config)
- Add comprehensive tests for all new features
