### PR TITLE
Enable autocompletion for -x flag with internal collections

### DIFF
--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -406,6 +406,19 @@ class ToolkitProgram(Program):
         """Flat arguments"""
         return {name: arg.value for name, arg in self.args.items()}
 
+    def _has_internal_col_flag_in_completion(self) -> bool:
+        """
+        Check if -x or --internal-col flag is present in the completion context.
+
+        When completion is triggered, we need to check if the command being
+        completed includes the -x flag, so we can load internal collections
+        for proper completion suggestions.
+        """
+        # Check if -x or --internal-col is in the argv (the command being completed)
+        if hasattr(self, "argv") and self.argv:
+            return "-x" in self.argv or "--internal-col" in self.argv
+        return False
+
     def parse_cleanup(self) -> None:
         """
         Post-parsing, pre-execution steps such as --help, --list, etc.
@@ -452,6 +465,19 @@ class ToolkitProgram(Program):
 
         # Print completion helpers if necessary
         if self.args.complete.value:
+            # Check if -x flag is in the completion context and load internal collections
+            # This ensures completions for internal tasks work when -x is passed
+            if self._has_internal_col_flag_in_completion():
+                debug(
+                    "Detected -x flag in completion context, loading internal collections"
+                )
+                if not self.args["internal-col"].value:
+                    # Load internal collections for completion context
+                    ToolkitCollection.from_package(  # pylint: disable=unexpected-keyword-arg
+                        "invoke_toolkit.extensions.tasks",
+                        self.collection,  # type: ignore
+                    )
+
             complete(
                 names=self.binary_names,
                 core=self.core,

--- a/tests/test_program_with_collection.py
+++ b/tests/test_program_with_collection.py
@@ -1,8 +1,11 @@
+import json
+import subprocess
+import sys
 from typing import Any
-from invoke_toolkit import task, Context
+
+from invoke_toolkit import Context, task
 from invoke_toolkit.collections import ToolkitCollection
 from invoke_toolkit.testing import TestingToolkitProgram
-import json
 
 
 @task()
@@ -30,4 +33,43 @@ def test_program_with_collection(capsys, suppress_stderr_logging):
     assert collections, "collections not found in -x"
     assert set(c["name"] for c in collections).issubset(
         set(["create", "config", "dist"])
+    )
+
+
+def test_completion_with_x_flag(suppress_stderr_logging):
+    """Test that completion includes internal collections when -x is passed"""
+    result = subprocess.run(
+        [sys.executable, "-m", "invoke_toolkit", "--complete", "--", "intk", "-x"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+
+    # Check that internal collections are in the completion output
+    assert "config" in output, "config collection should be in completion with -x"
+    assert "create" in output, "create collection should be in completion with -x"
+
+
+def test_completion_without_x_flag(suppress_stderr_logging):
+    """Test that completion does not include internal collections without -x"""
+    result = subprocess.run(
+        [sys.executable, "-m", "invoke_toolkit", "--complete", "--", "intk"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    lines = output.strip().split("\n")
+
+    # Count how many internal collection items appear
+    internal_items = sum(
+        1 for line in lines if "config." in line or "create." in line or "dist." in line
+    )
+
+    # There should be no internal collection items without -x
+    assert internal_items == 0, (
+        f"Found {internal_items} internal collection items without -x flag"
     )


### PR DESCRIPTION
Fixes #28

## Description
This PR enables autocompletion for the `-x` flag which enables internal collections.

When running `intk -x <Tab>`, the completion now shows the options that `intk -xl` displays, including internal collections (config, create, dist).

## Changes
- Add `_has_internal_col_flag_in_completion()` method to detect `-x` flag in completion context
- Load internal collections when completion is triggered with `-x` flag
- Add comprehensive tests to verify completion behavior

## Testing
- All existing tests pass (104 passed, 3 skipped)
- New tests verify:
  - `intk -x <Tab>` includes internal collections
  - `intk <Tab>` without `-x` does NOT include internal collections