### PR TITLE
fix: handle Path objects in autoprint without line breaks

### DIFF
--- a/src/invoke_toolkit/executor.py
+++ b/src/invoke_toolkit/executor.py
@@ -2,6 +2,7 @@
 Custom executor class to for Syntax highlighted output
 """
 
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from invoke.executor import Executor
@@ -140,7 +141,7 @@ class ToolkitExecutor(Executor):
                 # NOTE: Long strings will get wrapped when using autoprint in a console
                 #       we will use print for strings, for the case of piping output
                 #       and any non string type will be formatted by the console
-                if isinstance(result, str):
+                if isinstance(result, (str, Path)):
                     print(result)
                 else:
                     get_console("out").print(result)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -89,3 +89,32 @@ def test_auto_print_long_strings_single_line(
     lines = output.out.splitlines()
     assert len(lines) == 1, f"Expected 1 line but got {len(lines)} lines"
     assert lines[0] == long_string
+
+
+def test_auto_print_path_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """Test that Path objects are printed as single line without unwanted newlines"""
+    ns = ToolkitCollection()
+    p = TestingToolkitProgram(
+        version="test",
+        namespace=ns,
+        name="test",
+    )
+
+    # Create a Path object
+    test_path = tmp_path / "test_file.txt"
+
+    @task(autoprint=True)
+    def test_task(ctx: Context):
+        """A test function that returns a Path object"""
+        return test_path
+
+    ns.add_task(test_task)
+    p.run(["", "test-task"])
+    output = capsys.readouterr()
+
+    # The output should contain exactly one line with the path
+    lines = output.out.splitlines()
+    assert len(lines) == 1, f"Expected 1 line but got {len(lines)} lines"
+    assert lines[0] == str(test_path)


### PR DESCRIPTION
## Summary
Fixes #35 by treating Path objects like strings in the autoprint logic. Path objects were previously being passed to Rich's Console.print() which added unwanted newlines.

## Changes
- Modified `executor.py` to check for both `str` and `Path` types in the autoprint condition
- Added `Path` import from `pathlib`
- Added test case `test_auto_print_path_objects` to ensure Path objects are printed correctly as a single line

## Testing
All existing tests pass, and the new test verifies that Path objects are printed without unwanted newlines.