### PR TITLE
feat: add enum arguments support to tasks (#37)

### DIFF
--- a/src/invoke_toolkit/tasks/tasks.py
+++ b/src/invoke_toolkit/tasks/tasks.py
@@ -5,6 +5,7 @@ Type annotated tasks and and overrides over invoke
 # pylint: disable=too-many-statements
 
 import inspect
+import types
 from enum import Enum
 from functools import wraps
 from typing import (
@@ -73,11 +74,78 @@ def _extract_annotated_help(func: Any) -> dict[str, str]:
     return help_dict
 
 
+def _extract_literal_from_union(annotation: Any) -> tuple[Any, ...] | None:
+    """
+    Extract Literal values from a Union type (e.g., Literal["a", "b"] | None).
+
+    Handles both typing.Union and types.UnionType (Python 3.10+ |).
+
+    Args:
+        annotation: The Union type annotation to extract from
+
+    Returns:
+        Tuple of literal values if found, None otherwise
+    """
+    if not _is_union_type(annotation):
+        return None
+
+    args = get_args(annotation)
+    # Collect all literal values from any Literal types in the union
+    all_literals = []
+    for arg in args:
+        if get_origin(arg) is Literal:
+            all_literals.extend(get_args(arg))
+
+    return tuple(all_literals) if all_literals else None
+
+
+def _is_union_type(annotation: Any) -> bool:
+    """
+    Check if annotation is a Union type (typing.Union or types.UnionType).
+
+    Handles both typing.Union and types.UnionType (Python 3.10+ |).
+
+    Args:
+        annotation: The annotation to check
+
+    Returns:
+        True if the annotation is a Union type
+    """
+    origin = get_origin(annotation)
+    return origin is Union or isinstance(annotation, types.UnionType)
+
+
+def _extract_enum_from_union(annotation: Any) -> Type[Enum] | None:
+    """
+    Extract enum type from a Union type (e.g., Enum | None).
+
+    Handles both typing.Union and types.UnionType (Python 3.10+ |).
+
+    Args:
+        annotation: The Union type annotation to extract from
+
+    Returns:
+        The Enum class if found, None otherwise
+    """
+    if not _is_union_type(annotation):
+        return None
+
+    args = get_args(annotation)
+    for arg in args:
+        try:
+            if isinstance(arg, type) and issubclass(arg, Enum):
+                return arg
+        except TypeError:
+            pass
+    return None
+
+
 def _extract_enum_params(func: Any) -> dict[str, Type[Enum]]:
     """
     Extract enum type parameters from function signature.
 
     Handles both plain enum types and Annotated[Enum, ...].
+    Also handles Union types where one of the args is an Enum (e.g., Enum | None).
 
     Args:
         func: The function to extract enum parameters from
@@ -103,11 +171,18 @@ def _extract_enum_params(func: Any) -> dict[str, Type[Enum]]:
                 if args:
                     annotation = args[0]
 
+            # Try direct enum type
             try:
                 if isinstance(annotation, type) and issubclass(annotation, Enum):
                     enum_params[param_name] = annotation
+                    continue
             except TypeError:
                 pass
+
+            # Try Union types (e.g., Enum | None)
+            enum_from_union = _extract_enum_from_union(annotation)
+            if enum_from_union is not None:
+                enum_params[param_name] = enum_from_union
     except (ValueError, TypeError):
         pass
 
@@ -148,14 +223,11 @@ def _extract_literal_params(func: Any) -> dict[str, tuple[Any, ...]]:
             origin = get_origin(annotation)
             if origin is Literal:
                 literal_params[param_name] = get_args(annotation)
-            elif origin is Union:
-                # Check if all args are Literals
-                args = get_args(annotation)
-                if all(get_origin(arg) is Literal for arg in args):
-                    # Flatten all literal values
-                    all_literals = tuple(val for arg in args for val in get_args(arg))
-                    if all_literals:
-                        literal_params[param_name] = all_literals
+            elif _is_union_type(annotation):
+                # Try to extract Literal values from union (e.g., Literal["a", "b"] | None)
+                literal_values = _extract_literal_from_union(annotation)
+                if literal_values is not None:
+                    literal_params[param_name] = literal_values
     except (ValueError, TypeError):
         pass
 
@@ -172,6 +244,43 @@ def _literal_choices_help(literal_values: tuple[Any, ...]) -> str:
     """Generate help text with available literal choices."""
     values = ", ".join(str(v) for v in literal_values)
     return f"Options: {values}"
+
+
+def _handle_validation_error(
+    ctx: Optional[ToolkitContext],
+    param_name: str,
+    invalid_value: Any,
+    valid_values: str,
+) -> None:
+    """
+    Handle validation errors using rich output and exit.
+
+    When context is available, exits with a rich error message.
+    When context is not available, raises ValueError.
+
+    Args:
+        ctx: The ToolkitContext (optional)
+        param_name: Name of the parameter that failed validation
+        invalid_value: The invalid value that was provided
+        valid_values: String representation of valid values
+
+    Raises:
+        ValueError: When context is not available
+        SystemExit: When context is available (from ctx.rich_exit)
+    """
+    message = (
+        f"[red]Invalid value[/red] '[yellow]{invalid_value}[/yellow]' "
+        f"for parameter '[cyan]{param_name}[/cyan]'.\n"
+        f"[green]Must be one of:[/green] {valid_values}"
+    )
+    if ctx is not None:
+        ctx.rich_exit(message, exit_code=1)
+    else:
+        error_msg = (
+            f"Invalid value '{invalid_value}' for {param_name}. "
+            f"Must be one of: {valid_values}"
+        )
+        raise ValueError(error_msg)
 
 
 class ToolkitTask(Task): ...
@@ -282,6 +391,9 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
         # Create a wrapper that Invoke can work with
         @wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Get context from args[0] for error handling
+            ctx = args[0] if args and isinstance(args[0], ToolkitContext) else None
+
             # Convert string enum values to enum instances with validation
             if enum_params:
                 # Convert positional args
@@ -297,10 +409,12 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
                                 valid_values = ", ".join(
                                     str(m.value) for m in enum_class
                                 )
-                                raise ValueError(
-                                    f"Invalid value '{arg}' for {param_name}. "
-                                    f"Must be one of: {valid_values}"
-                                ) from exc
+                                try:
+                                    _handle_validation_error(
+                                        ctx, param_name, arg, valid_values
+                                    )
+                                except ValueError as validation_err:
+                                    raise validation_err from exc
                 args = tuple(args_list)
 
                 # Convert kwargs
@@ -310,10 +424,12 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
                             kwargs[param_name] = enum_class(kwargs[param_name])
                         except ValueError as exc:
                             valid_values = ", ".join(str(m.value) for m in enum_class)
-                            raise ValueError(
-                                f"Invalid value '{kwargs[param_name]}' for {param_name}. "
-                                f"Must be one of: {valid_values}"
-                            ) from exc
+                            try:
+                                _handle_validation_error(
+                                    ctx, param_name, kwargs[param_name], valid_values
+                                )
+                            except ValueError as validation_err:
+                                raise validation_err from exc
 
             # Validate literal values
             if literal_params:
@@ -321,18 +437,18 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
                     # Check kwargs
                     if param_name in kwargs:
                         if kwargs[param_name] not in literal_values:
-                            raise ValueError(
-                                f"Invalid value '{kwargs[param_name]}' for {param_name}. "
-                                f"Must be one of: {', '.join(str(v) for v in literal_values)}"
+                            valid_values = ", ".join(str(v) for v in literal_values)
+                            _handle_validation_error(
+                                ctx, param_name, kwargs[param_name], valid_values
                             )
 
                     # Check positional args
                     for i, param in enumerate(param_names):
                         if param == param_name and i < len(args):
                             if args[i] not in literal_values:
-                                raise ValueError(
-                                    f"Invalid value '{args[i]}' for {param_name}. "
-                                    f"Must be one of: {', '.join(str(v) for v in literal_values)}"
+                                valid_values = ", ".join(str(v) for v in literal_values)
+                                _handle_validation_error(
+                                    ctx, param_name, args[i], valid_values
                                 )
 
             return f(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,8 +122,11 @@ class TempVenv:
         return env
 
     def _call(
-        self, command: str, cwd: Path | None = None
-    ) -> subprocess.CompletedProcess[bytes]:
+        self,
+        command: str,
+        cwd: Path | None = None,
+        text: bool = False,
+    ) -> subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str]:
         """Internal call to the process"""
         result = subprocess.run(
             command,
@@ -133,15 +136,19 @@ class TempVenv:
             env=self._uv_venv,
             cwd=cwd,
             check=False,
+            text=text,
         )
         # assert result.returncode == 0
         return result
 
     def run(
-        self, command: str, cwd: Path | None = None
-    ) -> subprocess.CompletedProcess[bytes]:
+        self,
+        command: str,
+        cwd: Path | None = None,
+        text: bool = False,
+    ) -> subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str]:
         """Runs a command in the virtual environment"""
-        return self._call(f"uv run {command}", cwd=cwd)
+        return self._call(f"uv run {command}", cwd=cwd, text=text)
 
     def __repr__(self):
         return f"<temp venv at {self.path}>"

--- a/tests/examples/enum_select_size/tasks.py
+++ b/tests/examples/enum_select_size/tasks.py
@@ -1,0 +1,20 @@
+"""Tasks demonstrating enum parameter support."""
+
+from enum import Enum
+
+from invoke_toolkit import Context, task
+
+
+class Size(str, Enum):
+    """Size enumeration."""
+
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
+@task()
+def select_size(ctx: Context, size: Size | None = None):
+    """Select a size from available options."""
+    if size:
+        print(type(size))

--- a/tests/examples/literal_set_level/tasks.py
+++ b/tests/examples/literal_set_level/tasks.py
@@ -1,0 +1,12 @@
+"""Tasks demonstrating Literal type parameter support."""
+
+from typing import Literal
+
+from invoke_toolkit import Context, task
+
+
+@task()
+def set_level(ctx: Context, level: Literal["debug", "info", "error"] | None = None):
+    """Set log level from available options."""
+    if level:
+        print(f"Level: {level}")

--- a/tests/extensions/test_create.py
+++ b/tests/extensions/test_create.py
@@ -446,7 +446,8 @@ def test_tasks_and_entrypoints_merge(
 
     # Create the package
     temp_venv.run(
-        f"invoke-toolkit -x create.package --name {package_name} --location {tmp_path}"
+        f"invoke-toolkit -x create.package --name {package_name} --location {tmp_path}",
+        text=True,
     )
 
     # Install the newly created package
@@ -471,14 +472,15 @@ def test_tasks_and_entrypoints_merge(
     )
 
     # Now list tasks - should see both entry point tasks and local tasks
-    res = temp_venv.run("invoke-toolkit -dl", cwd=project_dir)
+    res = temp_venv.run("invoke-toolkit -dl", cwd=project_dir, text=True)
 
     assert res.returncode == 0, f"Error: {res.stdout} {res.stderr}"
 
     # Check that both the package entry point and local task are available
-    output = res.stderr.decode() if isinstance(res.stderr, bytes) else res.stderr
-    stdout = res.stdout.decode() if isinstance(res.stdout, bytes) else res.stdout
-    combined_output = output + stdout
+    # When text=True, stdout and stderr are str, not bytes
+    stderr = res.stderr if isinstance(res.stderr, str) else res.stderr.decode()
+    stdout = res.stdout if isinstance(res.stdout, str) else res.stdout.decode()
+    combined_output = stderr + stdout
 
     # Should have the entry point collection (invoke_toolkit_bar)
     assert "invoke_toolkit_bar" in combined_output or "hello" in combined_output, (
@@ -518,5 +520,5 @@ def test_create_package_create_venv_install_intk_and_package_and_list(
     temp_venv.add_package(tmp_pkg_path)
     # Separate test location
     other_place = tmp_path_factory.mktemp("other_place")
-    res = temp_venv.run("invoke-toolkit -l", cwd=other_place)
+    res = temp_venv.run("invoke-toolkit -l", cwd=other_place, text=True)
     assert res.returncode == 0

--- a/tests/test_enum_arguments.py
+++ b/tests/test_enum_arguments.py
@@ -5,7 +5,9 @@ These tests simulate real-world CLI usage where only string values are passed.
 
 # pylint: disable=unnecessary-pass
 
+import typing
 from enum import Enum
+from pathlib import Path
 from typing import Literal
 
 import pytest
@@ -17,6 +19,12 @@ from invoke_toolkit.tasks.tasks import (
     _extract_literal_params,
     task,
 )
+
+if typing.TYPE_CHECKING:
+    from tests.conftest import TempVenv
+
+# Path to example tasks
+EXAMPLES_DIR = Path(__file__).parent / "examples"
 
 
 class Color(str, Enum):
@@ -202,14 +210,8 @@ def test_enum_cli_invalid_value_error():
         pass
 
     ctx = ToolkitContext()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(SystemExit):
         paint(ctx, "purple")  # type: ignore[arg-type]
-
-    error_msg = str(exc_info.value)
-    assert "Invalid value 'purple' for color" in error_msg
-    assert "red" in error_msg
-    assert "green" in error_msg
-    assert "blue" in error_msg
 
 
 def test_enum_cli_with_multiple_params():
@@ -301,13 +303,8 @@ def test_literal_cli_invalid_value_error():
         pass
 
     ctx = ToolkitContext()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(SystemExit):
         build(ctx, "production")  # type: ignore[arg-type]
-
-    error_msg = str(exc_info.value)
-    assert "Invalid value 'production' for mode" in error_msg
-    assert "debug" in error_msg
-    assert "release" in error_msg
 
 
 def test_literal_union_cli():
@@ -458,7 +455,7 @@ def test_mixed_invalid_enum_cli():
         pass
 
     ctx = ToolkitContext()
-    with pytest.raises(ValueError, match="Invalid value"):
+    with pytest.raises(SystemExit):
         configure(ctx, "invalid", "fast")  # type: ignore[arg-type]
 
 
@@ -475,7 +472,7 @@ def test_mixed_invalid_literal_cli():
         pass
 
     ctx = ToolkitContext()
-    with pytest.raises(ValueError, match="Invalid value"):
+    with pytest.raises(SystemExit):
         configure(ctx, "red", "medium")  # type: ignore[arg-type]
 
 
@@ -554,19 +551,8 @@ def test_enum_error_shows_all_options():
         pass
 
     ctx = ToolkitContext()
-    try:
+    with pytest.raises(SystemExit):
         paint(ctx, "invalid")  # type: ignore[arg-type]
-        pytest.fail("Should have raised ValueError")
-    except ValueError as e:
-        error_msg = str(e)
-        # Should mention the invalid value
-        assert "invalid" in error_msg
-        # Should mention the parameter
-        assert "color" in error_msg
-        # Should list all valid values
-        assert "red" in error_msg
-        assert "green" in error_msg
-        assert "blue" in error_msg
 
 
 def test_literal_error_shows_all_options():
@@ -578,12 +564,45 @@ def test_literal_error_shows_all_options():
         pass
 
     ctx = ToolkitContext()
-    try:
+    with pytest.raises(SystemExit):
         build(ctx, "test")  # type: ignore[arg-type]
-        pytest.fail("Should have raised ValueError")
-    except ValueError as e:
-        error_msg = str(e)
-        assert "test" in error_msg
-        assert "mode" in error_msg
-        assert "debug" in error_msg
-        assert "release" in error_msg
+
+
+def test_task_integration_flags(
+    temp_venv: "TempVenv",
+    git_root: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VIRTUAL_ENV", "")
+    monkeypatch.chdir(tmp_path)
+    temp_venv.add_package(git_root, editable=True)
+
+    # Copy the tasks.py from enum_select_size example to tmp_path
+    example_tasks = EXAMPLES_DIR / "enum_select_size" / "tasks.py"
+    tasks_py: Path = tmp_path / "tasks.py"
+    tasks_py.write_text(example_tasks.read_text())
+
+    result = temp_venv.run("invoke-toolkit select-size -s small", text=True)
+
+    assert "<enum 'Size'>" in result.stdout
+
+
+def test_task_integration_literal(
+    temp_venv: "TempVenv",
+    git_root: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VIRTUAL_ENV", "")
+    monkeypatch.chdir(tmp_path)
+    temp_venv.add_package(git_root, editable=True)
+
+    # Copy the tasks.py from literal_set_level example to tmp_path
+    example_tasks = EXAMPLES_DIR / "literal_set_level" / "tasks.py"
+    tasks_py: Path = tmp_path / "tasks.py"
+    tasks_py.write_text(example_tasks.read_text())
+
+    result = temp_venv.run("invoke-toolkit set-level -l debug", text=True)
+
+    assert "Level: debug" in result.stdout


### PR DESCRIPTION
- Add support for enum and Literal type parameters
- Automatic string-to-enum/Literal conversion with validation
- Support Python 3.10+ union syntax (Type | None)
- Consolidate validation with ctx.rich_exit() for rich error messages
- Extract enum/literal from Union types
- Help text with available options for both enum and Literal parameters
- Example tasks in tests/examples/ for independent testing
- 32 tests covering CLI usage, validation, and edge cases
- All tests passing with 100% type checking