### PR TITLE
feat: add cache parameter to @task decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This extends the Collection from Invoke so it can create automatically collectio
 - Discovery to *plain old* tasks.py (or any other name)
 - Local tasks discovery from `local_tasks.py` in the current directory
 - Integration with stand alone binaries for specific tasks
+- **Task result caching** with TTL support via `diskcache` (optional)
 - **Future** Download binaries
 
 ## Do I need this package
@@ -67,6 +68,43 @@ intk local.my-task
 ```
 
 Local tasks are automatically discovered and added to the `local` namespace, allowing you to keep project-specific tasks separate from your main task collection.
+
+### Using Task Caching
+
+Cache expensive task results with the `cache` parameter:
+
+```python
+from invoke_toolkit import task
+
+# Simple caching (no expiration)
+@task(cache=True)
+def expensive_task(ctx, param: str) -> str:
+    """Results are cached across invocations."""
+    return do_expensive_computation(param)
+
+# Caching with TTL (1 hour)
+@task(cache={"ttl": 3600})
+def cached_task(ctx, name: str) -> dict:
+    """Results cached for 1 hour."""
+    return fetch_data(name)
+
+# Caching with ignored arguments
+@task(cache={"ttl": 600, "ignore_args": ["verbose"]})
+def cached_with_options(ctx, query: str, verbose: bool = False) -> list:
+    """Cache key ignores verbose flag."""
+    return search(query, verbose=verbose)
+```
+
+Cache features:
+- Cache location is computed from git repository root + platformdirs
+- Debug logging (`-d` flag) shows cache hits/misses
+- Graceful degradation when `diskcache` is not installed
+
+To enable caching, install with the cache extra:
+
+```console
+pip install invoke-toolkit[cache]
+```
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ exclude_lines = [
 "src/invoke_toolkit/program/program.py" = ["E402"]
 
 [project.optional-dependencies]
+cache = [
+  "diskcache>=5.6.0",
+]
 copier = [
   "copier>=9.10.3",
 ]
@@ -125,6 +128,7 @@ debug = [
 ]
 full = [
   "copier>=9.10.3",
+  "diskcache>=5.6.0",
   "hunter>=3.7.0",
   "pdbpp>=0.11.7",
 ]
@@ -136,6 +140,7 @@ ci = [
 dev = [
     "attrs>=24.1.0",
     "copier>=9.10.3",
+    "diskcache>=5.6.0",
     "hunter>=3.7.0",
     "pdbpp>=0.11.7",
     "pre-commit>=4.3.0",

--- a/src/invoke_toolkit/__init__.py
+++ b/src/invoke_toolkit/__init__.py
@@ -12,7 +12,13 @@ from invoke_toolkit.config.config import ToolkitConfig as Config  # noqa
 from invoke_toolkit.context import ToolkitContext as Context  # noqa
 from invoke_toolkit.parser import ToolkitArgument  # noqa
 from invoke_toolkit.scripts.loader import script  # noqa
-from invoke_toolkit.tasks import call, task  # noqa
+from invoke_toolkit.tasks import (  # noqa
+    CacheConfig,
+    cache_stats,
+    call,
+    clear_task_cache,
+    task,
+)
 from invoke_toolkit.tasks.types import (
     DirPath as DirPath,
     DirPathStr as DirPathStr,

--- a/src/invoke_toolkit/tasks/__init__.py
+++ b/src/invoke_toolkit/tasks/__init__.py
@@ -1,2 +1,3 @@
-from .tasks import task, Call, call, ToolkitTask  # noqa: F401
-from .types import FilePath, FilePattern, DirPath  # noqa: F401
+from .cache import CacheConfig, cache_stats, clear_task_cache  # noqa: F401
+from .tasks import Call, ToolkitTask, call, task  # noqa: F401
+from .types import DirPath, FilePath, FilePattern  # noqa: F401

--- a/src/invoke_toolkit/tasks/cache.py
+++ b/src/invoke_toolkit/tasks/cache.py
@@ -1,0 +1,323 @@
+"""
+Task caching functionality using diskcache as backend.
+
+Provides optional caching for task results with:
+- Automatic cache location based on git repository root + platformdirs
+- TTL (time-to-live) support
+- Debug logging for cache hits/misses
+- Graceful degradation when diskcache is not installed
+"""
+
+import hashlib
+import subprocess
+from dataclasses import dataclass, field
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, Optional, TypeVar, Union
+
+import platformdirs
+from invoke.util import debug
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Check if diskcache is available
+try:
+    import diskcache
+
+    DISKCACHE_AVAILABLE = True
+except ImportError:
+    diskcache = None  # type: ignore[assignment]
+    DISKCACHE_AVAILABLE = False
+
+
+@dataclass
+class CacheConfig:
+    """Configuration for task caching."""
+
+    enabled: bool = True
+    ttl: Optional[float] = None  # Time-to-live in seconds, None means no expiration
+    key_prefix: str = ""  # Optional prefix for cache keys
+    ignore_args: list[str] = field(
+        default_factory=list
+    )  # Arguments to exclude from cache key
+
+
+def get_git_root() -> Optional[Path]:
+    """
+    Get the root directory of the current git repository.
+
+    Returns:
+        Path to git root directory, or None if not in a git repository.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def get_cache_directory() -> Path:
+    """
+    Compute the cache directory for invoke-toolkit tasks.
+
+    The cache location is computed as:
+    - platformdirs user_cache_dir / "invoke-toolkit" / git_repo_hash
+
+    If not in a git repository, uses a generic "no-repo" subdirectory.
+
+    Returns:
+        Path to the cache directory.
+    """
+    base_cache = Path(platformdirs.user_cache_dir("invoke-toolkit"))
+    cache_subdir = "tasks"
+
+    git_root = get_git_root()
+    if git_root:
+        # Create a hash of the git root path to avoid conflicts
+        repo_hash = hashlib.md5(str(git_root).encode()).hexdigest()[:12]
+        cache_dir = base_cache / cache_subdir / repo_hash
+    else:
+        cache_dir = base_cache / cache_subdir / "no-repo"
+
+    return cache_dir
+
+
+def make_cache_key(
+    func_name: str, args: tuple, kwargs: dict, ignore_args: list[str]
+) -> str:
+    """
+    Create a cache key from function name and arguments.
+
+    Args:
+        func_name: Name of the function being cached.
+        args: Positional arguments (excluding context which is first arg).
+        kwargs: Keyword arguments.
+        ignore_args: List of argument names to exclude from cache key.
+
+    Returns:
+        A string cache key.
+    """
+    # Filter out ignored arguments from kwargs
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k not in ignore_args}
+
+    # Create a deterministic string representation
+    key_parts = [func_name]
+
+    # Add positional args (skip first arg which is context)
+    if args:
+        for arg in args:
+            key_parts.append(repr(arg))
+
+    # Add sorted kwargs for determinism
+    for k in sorted(filtered_kwargs.keys()):
+        key_parts.append(f"{k}={filtered_kwargs[k]!r}")
+
+    key_string = ":".join(key_parts)
+
+    # Hash if too long
+    if len(key_string) > 200:
+        return hashlib.sha256(key_string.encode()).hexdigest()
+
+    return key_string
+
+
+def get_cache(cache_dir: Optional[Path] = None) -> Optional["diskcache.Cache"]:
+    """
+    Get or create the diskcache Cache instance.
+
+    Args:
+        cache_dir: Optional custom cache directory. If None, uses default.
+
+    Returns:
+        A diskcache.Cache instance, or None if diskcache is not available.
+    """
+    if not DISKCACHE_AVAILABLE:
+        return None
+
+    if cache_dir is None:
+        cache_dir = get_cache_directory()
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return diskcache.Cache(str(cache_dir))
+
+
+def cached_task_wrapper(
+    func: F,
+    config: CacheConfig,
+) -> F:
+    """
+    Wrap a task function with caching logic.
+
+    Args:
+        func: The original task function.
+        config: Cache configuration.
+
+    Returns:
+        Wrapped function with caching.
+    """
+    if not config.enabled:
+        return func
+
+    func_name = getattr(func, "__name__", repr(func))
+
+    if not DISKCACHE_AVAILABLE:
+        debug(f"diskcache not installed, caching disabled for {func_name}")
+        return func
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        # Get or create cache
+        cache = get_cache()
+        if cache is None:
+            debug(f"Could not create cache for {func_name}, running without cache")
+            return func(*args, **kwargs)
+
+        try:
+            # Create cache key (skip first arg which is context)
+            cache_args = args[1:] if args else ()
+            key = make_cache_key(
+                func_name=f"{config.key_prefix}{func_name}",
+                args=cache_args,
+                kwargs=kwargs,
+                ignore_args=config.ignore_args,
+            )
+
+            # Try to get from cache
+            result = cache.get(key, default=None)
+            if result is not None:
+                debug(f"Cache HIT for {func_name} (key: {key[:50]}...)")
+                return result
+
+            debug(f"Cache MISS for {func_name} (key: {key[:50]}...)")
+
+            # Execute function and cache result
+            result = func(*args, **kwargs)
+
+            # Only cache non-None results
+            if result is not None:
+                cache.set(key, result, expire=config.ttl)
+                debug(f"Cached result for {func_name} (ttl: {config.ttl})")
+
+            return result
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            # On any cache error, just run the function
+            debug(f"Cache error for {func_name}: {e}, running without cache")
+            return func(*args, **kwargs)
+        finally:
+            cache.close()
+
+    return wrapper  # type: ignore[return-value]
+
+
+def parse_cache_config(
+    cache_param: Union[bool, dict, CacheConfig, None],
+) -> Optional[CacheConfig]:
+    """
+    Parse the cache parameter into a CacheConfig.
+
+    Args:
+        cache_param: The cache parameter from the @task decorator.
+            - True: Enable caching with defaults
+            - False/None: Disable caching
+            - dict: Enable with custom settings (ttl, key_prefix, ignore_args)
+            - CacheConfig: Use as-is
+
+    Returns:
+        CacheConfig instance or None if caching should be disabled.
+    """
+    if cache_param is None or cache_param is False:
+        return None
+
+    if isinstance(cache_param, CacheConfig):
+        return cache_param
+
+    if cache_param is True:
+        return CacheConfig()
+
+    if isinstance(cache_param, dict):
+        return CacheConfig(
+            enabled=cache_param.get("enabled", True),
+            ttl=cache_param.get("ttl"),
+            key_prefix=cache_param.get("key_prefix", ""),
+            ignore_args=cache_param.get("ignore_args", []),
+        )
+
+    return None
+
+
+def clear_task_cache(task_name: Optional[str] = None) -> int:
+    """
+    Clear the task cache.
+
+    Args:
+        task_name: If provided, only clear cache entries for this task.
+                   If None, clear all task cache entries.
+
+    Returns:
+        Number of entries cleared.
+    """
+    if not DISKCACHE_AVAILABLE:
+        debug("diskcache not installed, nothing to clear")
+        return 0
+
+    cache = get_cache()
+    if cache is None:
+        return 0
+
+    try:
+        if task_name is None:
+            # Clear all
+            count = len(cache)
+            cache.clear()
+            debug(f"Cleared {count} cache entries")
+            return count
+
+        # Clear entries for specific task
+        count = 0
+        keys_to_delete = []
+        for key in cache.iterkeys():
+            if isinstance(key, str) and key.startswith(task_name):
+                keys_to_delete.append(key)
+
+        for key in keys_to_delete:
+            del cache[key]
+            count += 1
+
+        debug(f"Cleared {count} cache entries for task {task_name}")
+        return count
+    finally:
+        cache.close()
+
+
+def cache_stats() -> dict[str, Any]:
+    """
+    Get cache statistics.
+
+    Returns:
+        Dictionary with cache statistics.
+    """
+    if not DISKCACHE_AVAILABLE:
+        return {"available": False}
+
+    cache = get_cache()
+    if cache is None:
+        return {"available": False}
+
+    try:
+        stats = {
+            "available": True,
+            "directory": str(cache.directory),
+            "size": len(cache),
+            "volume": cache.volume(),
+        }
+        return stats
+    finally:
+        cache.close()

--- a/src/invoke_toolkit/tasks/tasks.py
+++ b/src/invoke_toolkit/tasks/tasks.py
@@ -31,7 +31,15 @@ from invoke import task as invoke_task
 from invoke.tasks import Call, Task
 
 from invoke_toolkit.context import ToolkitContext
+from invoke_toolkit.tasks.cache import (
+    CacheConfig,
+    cached_task_wrapper,
+    parse_cache_config,
+)
 from invoke_toolkit.tasks.types import _FileCompletionMarker
+
+# Type alias for cache parameter
+CacheParam = Union[bool, dict, CacheConfig, None]
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -449,6 +457,7 @@ def task(
     post: Optional[list[Callable[..., Any]]] = None,
     klass: Optional[Type["ToolkitTask"]] = ToolkitTask,
     proctitle: Optional[str] = None,
+    cache: CacheParam = None,
 ) -> F: ...
 
 
@@ -470,6 +479,7 @@ def task(
     post: Optional[list[Callable[..., Any]]] = None,
     klass: Optional[Type["ToolkitTask"]] = ToolkitTask,
     proctitle: Optional[str] = None,
+    cache: CacheParam = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -490,6 +500,7 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
     post: Optional[list[Callable[..., Any]]] = None,
     klass: Optional[Type["ToolkitTask"]] = ToolkitTask,
     proctitle: Optional[str] = None,
+    cache: CacheParam = None,
 ) -> Any:
     """
     Decorator for Invoke tasks that preserves type hints and Context annotation.
@@ -503,6 +514,17 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
 
     The proctitle parameter allows setting the process title while the task runs.
     When the task completes, the original process title is restored.
+
+    Args:
+        cache: Optional caching configuration for task results. Can be:
+            - True: Enable caching with defaults
+            - False/None: Disable caching (default)
+            - dict: Enable with custom settings (ttl, key_prefix, ignore_args)
+            - CacheConfig: Use a CacheConfig instance directly
+
+            Cache location is computed from git repository root + platformdirs.
+            Requires 'diskcache' package to be installed; gracefully degrades if not available.
+            Cache hits/misses are logged when using -d (debug mode).
 
     Usage:
         @task
@@ -538,6 +560,24 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
             '''Task with custom process title.'''
             # Process title is "Processing data" while running
             do_processing()
+
+        # Using caching - simple (no TTL)
+        @task(cache=True)
+        def expensive_task(ctx: Context, param: str) -> str:
+            '''Results are cached across invocations.'''
+            return do_expensive_computation(param)
+
+        # Using caching with TTL (1 hour)
+        @task(cache={"ttl": 3600})
+        def cached_task(ctx: Context, name: str) -> dict:
+            '''Results cached for 1 hour.'''
+            return fetch_data(name)
+
+        # Using caching with ignore_args (ctx excluded by default)
+        @task(cache={"ttl": 600, "ignore_args": ["verbose"]})
+        def cached_with_options(ctx: Context, query: str, verbose: bool = False) -> list:
+            '''Cache key ignores verbose flag.'''
+            return search(query, verbose=verbose)
     """
 
     def decorator(f: F) -> F:
@@ -756,8 +796,15 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
         if default is not None:
             task_kwargs["default"] = default
 
+        # Apply caching wrapper if configured
+        cache_config = parse_cache_config(cache)
+        if cache_config is not None:
+            cached_wrapper = cached_task_wrapper(wrapper, cache_config)
+        else:
+            cached_wrapper = wrapper
+
         # Apply the Invoke @task decorator
-        task_decorated = invoke_task(wrapper, klass=klass, **task_kwargs)
+        task_decorated = invoke_task(cached_wrapper, klass=klass, **task_kwargs)
 
         # Store reference to original function
         task_decorated.__wrapped__ = f  # type: ignore[attr-defined]

--- a/tests/tasks/test_cache.py
+++ b/tests/tasks/test_cache.py
@@ -1,0 +1,485 @@
+"""
+Tests for task caching functionality.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from invoke_toolkit import Context, task
+from invoke_toolkit.tasks.cache import (
+    DISKCACHE_AVAILABLE,
+    CacheConfig,
+    cache_stats,
+    cached_task_wrapper,
+    clear_task_cache,
+    get_cache,
+    get_cache_directory,
+    get_git_root,
+    make_cache_key,
+    parse_cache_config,
+)
+
+# Tests for get_git_root function
+
+
+def test_get_git_root_returns_path_in_git_repo(tmp_path: Path):
+    """Should return the git root when inside a git repository."""
+    # Initialize a git repo in tmp_path
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+
+    # Change to the tmp_path and check
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=str(tmp_path))
+        result = get_git_root()
+        assert result is not None
+        assert isinstance(result, Path)
+
+
+def test_get_git_root_returns_none_outside_git_repo():
+    """Should return None when not in a git repository."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=128, stdout="")
+        result = get_git_root()
+        assert result is None
+
+
+def test_get_git_root_handles_timeout():
+    """Should return None on timeout."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=5)
+        result = get_git_root()
+        assert result is None
+
+
+# Tests for get_cache_directory function
+
+
+def test_get_cache_directory_returns_path():
+    """Should return a Path object."""
+    cache_dir = get_cache_directory()
+    assert isinstance(cache_dir, Path)
+
+
+def test_get_cache_directory_includes_invoke_toolkit_in_path():
+    """Cache directory should include invoke-toolkit."""
+    cache_dir = get_cache_directory()
+    assert "invoke-toolkit" in str(cache_dir)
+
+
+def test_get_cache_directory_uses_repo_hash_when_in_git():
+    """Should use git repo hash when in a git repository."""
+    with patch("invoke_toolkit.tasks.cache.get_git_root") as mock_git_root:
+        mock_git_root.return_value = Path("/some/repo/path")
+        cache_dir = get_cache_directory()
+        # Should not contain "no-repo"
+        assert "no-repo" not in str(cache_dir)
+
+
+def test_get_cache_directory_uses_no_repo_when_outside_git():
+    """Should use no-repo subdirectory when not in git."""
+    with patch("invoke_toolkit.tasks.cache.get_git_root") as mock_git_root:
+        mock_git_root.return_value = None
+        cache_dir = get_cache_directory()
+        assert "no-repo" in str(cache_dir)
+
+
+# Tests for make_cache_key function
+
+
+def test_make_cache_key_basic_key_generation():
+    """Should generate a key from function name and args."""
+    key = make_cache_key("my_func", ("arg1",), {"kwarg1": "value1"}, [])
+    assert "my_func" in key
+    assert "arg1" in key
+    assert "kwarg1" in key
+
+
+def test_make_cache_key_ignores_specified_args():
+    """Should ignore args in ignore_args list."""
+    key = make_cache_key(
+        "my_func", (), {"include_me": "yes", "ignore_me": "no"}, ["ignore_me"]
+    )
+    assert "include_me" in key
+    assert "ignore_me" not in key
+
+
+def test_make_cache_key_deterministic_keys():
+    """Same inputs should produce same key."""
+    key1 = make_cache_key("func", ("a", "b"), {"x": 1, "y": 2}, [])
+    key2 = make_cache_key("func", ("a", "b"), {"x": 1, "y": 2}, [])
+    assert key1 == key2
+
+
+def test_make_cache_key_different_args_different_keys():
+    """Different args should produce different keys."""
+    key1 = make_cache_key("func", ("a",), {}, [])
+    key2 = make_cache_key("func", ("b",), {}, [])
+    assert key1 != key2
+
+
+def test_make_cache_key_long_keys_are_hashed():
+    """Keys longer than 200 chars should be hashed."""
+    long_arg = "x" * 300
+    key = make_cache_key("func", (long_arg,), {}, [])
+    # SHA256 hash is 64 chars
+    assert len(key) == 64
+
+
+# Tests for parse_cache_config function
+
+
+def test_parse_cache_config_none_returns_none():
+    """None should return None."""
+    assert parse_cache_config(None) is None
+
+
+def test_parse_cache_config_false_returns_none():
+    """False should return None."""
+    assert parse_cache_config(False) is None
+
+
+def test_parse_cache_config_true_returns_default_config():
+    """True should return default CacheConfig."""
+    config = parse_cache_config(True)
+    assert config is not None
+    assert config.enabled is True
+    assert config.ttl is None
+
+
+def test_parse_cache_config_dict_with_ttl():
+    """Dict with ttl should set ttl."""
+    config = parse_cache_config({"ttl": 3600})
+    assert config is not None
+    assert config.ttl == 3600
+
+
+def test_parse_cache_config_dict_with_ignore_args():
+    """Dict with ignore_args should set ignore_args."""
+    config = parse_cache_config({"ignore_args": ["verbose", "debug"]})
+    assert config is not None
+    assert "verbose" in config.ignore_args
+    assert "debug" in config.ignore_args
+
+
+def test_parse_cache_config_dict_with_key_prefix():
+    """Dict with key_prefix should set key_prefix."""
+    config = parse_cache_config({"key_prefix": "myapp:"})
+    assert config is not None
+    assert config.key_prefix == "myapp:"
+
+
+def test_parse_cache_config_cache_config_passthrough():
+    """CacheConfig instance should pass through unchanged."""
+    original = CacheConfig(ttl=1800, key_prefix="test:")
+    config = parse_cache_config(original)
+    assert config is original
+
+
+# Tests for get_cache function
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_get_cache_returns_cache_instance(tmp_path: Path):
+    """Should return a diskcache.Cache instance."""
+    cache = get_cache(tmp_path)
+    assert cache is not None
+    cache.close()
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_get_cache_creates_directory(tmp_path: Path):
+    """Should create the cache directory if it doesn't exist."""
+    cache_dir = tmp_path / "new_cache_dir"
+    cache = get_cache(cache_dir)
+    assert cache is not None
+    assert cache_dir.exists()
+    cache.close()
+
+
+# Tests for cached_task_wrapper function
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cached_task_wrapper_caches_result(tmp_path: Path):
+    """Should cache function results."""
+    call_count = 0
+
+    def my_func(ctx, x):
+        nonlocal call_count
+        call_count += 1
+        return x * 2
+
+    config = CacheConfig()
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+        wrapped = cached_task_wrapper(my_func, config)
+        ctx = MagicMock()
+
+        # First call - should execute function
+        result1 = wrapped(ctx, 5)
+        assert result1 == 10
+        assert call_count == 1
+
+        # Second call with same args - should use cache
+        result2 = wrapped(ctx, 5)
+        assert result2 == 10
+        assert call_count == 1  # Still 1, cached
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cached_task_wrapper_different_args_not_cached(tmp_path: Path):
+    """Different args should not use cached result."""
+    call_count = 0
+
+    def my_func(ctx, x):
+        nonlocal call_count
+        call_count += 1
+        return x * 2
+
+    config = CacheConfig()
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+        wrapped = cached_task_wrapper(my_func, config)
+        ctx = MagicMock()
+
+        wrapped(ctx, 5)
+        assert call_count == 1
+
+        wrapped(ctx, 10)
+        assert call_count == 2  # Different arg, new call
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cached_task_wrapper_disabled_config_no_caching():
+    """Disabled config should not wrap function."""
+
+    def my_func(ctx, x):
+        return x
+
+    config = CacheConfig(enabled=False)
+    wrapped = cached_task_wrapper(my_func, config)
+
+    # Should return original function
+    assert wrapped is my_func
+
+
+# Tests for clear_task_cache function
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_clear_task_cache_clears_all_entries(tmp_path: Path):
+    """Should clear all cache entries."""
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+        cache = get_cache()
+        assert cache is not None
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.close()
+
+        cleared = clear_task_cache()
+        assert cleared == 2
+
+        # Verify cache is empty
+        cache = get_cache()
+        assert cache is not None
+        assert len(cache) == 0
+        cache.close()
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_clear_task_cache_clears_specific_task(tmp_path: Path):
+    """Should clear only entries for specific task."""
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+        cache = get_cache()
+        assert cache is not None
+        cache.set("my_task:arg1", "value1")
+        cache.set("my_task:arg2", "value2")
+        cache.set("other_task:arg1", "value3")
+        cache.close()
+
+        cleared = clear_task_cache("my_task")
+        assert cleared == 2
+
+        # Verify only other_task remains
+        cache = get_cache()
+        assert cache is not None
+        assert len(cache) == 1
+        cache.close()
+
+
+# Tests for cache_stats function
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cache_stats_returns_stats_dict(tmp_path: Path):
+    """Should return dictionary with stats."""
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+        stats = cache_stats()
+
+        assert isinstance(stats, dict)
+        assert stats["available"] is True
+        assert "directory" in stats
+        assert "size" in stats
+
+
+# Tests for graceful degradation when diskcache is not installed
+
+
+def test_get_cache_returns_none_without_diskcache():
+    """get_cache should return None when diskcache unavailable."""
+    with patch("invoke_toolkit.tasks.cache.DISKCACHE_AVAILABLE", False):
+        result = get_cache()
+        assert result is None
+
+
+def test_wrapper_returns_original_without_diskcache():
+    """cached_task_wrapper should return original func."""
+
+    def my_func(ctx, x):
+        return x
+
+    config = CacheConfig()
+
+    with patch("invoke_toolkit.tasks.cache.DISKCACHE_AVAILABLE", False):
+        wrapped = cached_task_wrapper(my_func, config)
+        assert wrapped is my_func
+
+
+def test_clear_cache_returns_zero_without_diskcache():
+    """clear_task_cache should return 0 when diskcache unavailable."""
+    with patch("invoke_toolkit.tasks.cache.DISKCACHE_AVAILABLE", False):
+        result = clear_task_cache()
+        assert result == 0
+
+
+def test_cache_stats_returns_unavailable_without_diskcache():
+    """cache_stats should indicate unavailability."""
+    with patch("invoke_toolkit.tasks.cache.DISKCACHE_AVAILABLE", False):
+        stats = cache_stats()
+        assert stats == {"available": False}
+
+
+# Integration tests for @task decorator with cache parameter
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_task_with_cache_true(ctx: Context, tmp_path: Path):
+    """Task with cache=True should cache results."""
+    call_count = 0
+
+    @task(cache=True)
+    def cached_task(c: Context, value: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return value * 2
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+
+        # Call the task body directly (simulating invoke behavior)
+        result1 = cached_task.body(ctx, 5)
+        assert result1 == 10
+        assert call_count == 1
+
+        result2 = cached_task.body(ctx, 5)
+        assert result2 == 10
+        assert call_count == 1  # Cached
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_task_with_cache_ttl(ctx: Context, tmp_path: Path):
+    """Task with cache TTL should work."""
+
+    @task(cache={"ttl": 3600})
+    def cached_with_ttl(c: Context, value: str) -> str:
+        return f"processed: {value}"
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+
+        result = cached_with_ttl.body(ctx, "test")
+        assert result == "processed: test"
+
+
+def test_task_without_cache(ctx: Context):
+    """Task without cache parameter should not cache."""
+    call_count = 0
+
+    @task
+    def uncached_task(c: Context, value: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return value * 2
+
+    result1 = uncached_task.body(ctx, 5)  # type: ignore[attr-defined]
+    result2 = uncached_task.body(ctx, 5)  # type: ignore[attr-defined]
+
+    assert result1 == 10
+    assert result2 == 10
+    assert call_count == 2  # Called twice, no caching
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_task_with_cache_false(ctx: Context):
+    """Task with cache=False should not cache."""
+    call_count = 0
+
+    @task(cache=False)
+    def no_cache_task(c: Context, value: int) -> int:
+        nonlocal call_count
+        call_count += 1
+        return value * 2
+
+    no_cache_task.body(ctx, 5)
+    no_cache_task.body(ctx, 5)
+
+    assert call_count == 2
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cache_none_result_not_cached(ctx: Context, tmp_path: Path):
+    """None results should not be cached."""
+    call_count = 0
+
+    @task(cache=True)
+    def returns_none(c: Context) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+
+        returns_none.body(ctx)
+        returns_none.body(ctx)
+
+        # Should be called twice since None is not cached
+        assert call_count == 2
+
+
+@pytest.mark.skipif(not DISKCACHE_AVAILABLE, reason="diskcache not installed")
+def test_cache_with_ignore_args(ctx: Context, tmp_path: Path):
+    """Cache should ignore specified arguments."""
+    call_count = 0
+
+    @task(cache={"ignore_args": ["verbose"]})
+    def task_with_verbose(c: Context, query: str, verbose: bool = False) -> str:
+        nonlocal call_count
+        call_count += 1
+        return f"result: {query}"
+
+    with patch("invoke_toolkit.tasks.cache.get_cache_directory") as mock_dir:
+        mock_dir.return_value = tmp_path
+
+        result1 = task_with_verbose.body(ctx, "test", verbose=False)
+        result2 = task_with_verbose.body(ctx, "test", verbose=True)
+
+        assert result1 == result2
+        assert call_count == 1  # Only called once, verbose is ignored

--- a/uv.lock
+++ b/uv.lock
@@ -405,6 +405,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -663,6 +672,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cache = [
+    { name = "diskcache" },
+]
 copier = [
     { name = "copier" },
 ]
@@ -672,6 +684,7 @@ debug = [
 ]
 full = [
     { name = "copier" },
+    { name = "diskcache" },
     { name = "hunter" },
     { name = "pdbpp" },
 ]
@@ -686,6 +699,7 @@ ci = [
 dev = [
     { name = "attrs" },
     { name = "copier" },
+    { name = "diskcache" },
     { name = "hunter" },
     { name = "pdbpp" },
     { name = "pre-commit" },
@@ -710,6 +724,8 @@ requires-dist = [
     { name = "copier", marker = "extra == 'copier'", specifier = ">=9.10.3" },
     { name = "copier", marker = "extra == 'full'", specifier = ">=9.10.3" },
     { name = "copier", marker = "extra == 'templating'", specifier = ">=9.10.3" },
+    { name = "diskcache", marker = "extra == 'cache'", specifier = ">=5.6.0" },
+    { name = "diskcache", marker = "extra == 'full'", specifier = ">=5.6.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hunter", marker = "extra == 'debug'", specifier = ">=3.7.0" },
     { name = "hunter", marker = "extra == 'full'", specifier = ">=3.7.0" },
@@ -724,13 +740,14 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13.3" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
 ]
-provides-extras = ["copier", "debug", "full", "templating"]
+provides-extras = ["cache", "copier", "debug", "full", "templating"]
 
 [package.metadata.requires-dev]
 ci = [{ name = "nox", specifier = ">=2025.10.16" }]
 dev = [
     { name = "attrs", specifier = ">=24.1.0" },
     { name = "copier", specifier = ">=9.10.3" },
+    { name = "diskcache", specifier = ">=5.6.0" },
     { name = "hunter", specifier = ">=3.7.0" },
     { name = "pdbpp", specifier = ">=0.11.7" },
     { name = "pre-commit", specifier = ">=4.3.0" },


### PR DESCRIPTION
## Summary

Implements task result caching using diskcache as backend, addressing issue #42.

## Features

- **Cache parameter** for `@task` decorator supporting multiple formats:
  - `cache=True` for simple caching with defaults
  - `cache={'ttl': 3600}` for TTL-based caching
  - `cache={'ignore_args': ['verbose']}` to exclude args from cache key
  - `cache=CacheConfig(...)` for full configuration control

- **Cache location** computed from:
  - Git repository root (hashed for uniqueness)
  - platformdirs user cache directory

- **Debug logging** shows cache hits/misses when using `-d` flag

- **Graceful degradation** when `diskcache` is not installed

- **Helper functions**:
  - `clear_task_cache()` - Clear cache entries
  - `cache_stats()` - Get cache statistics

## Usage Examples

```python
from invoke_toolkit import task

# Simple caching (no expiration)
@task(cache=True)
def expensive_task(ctx, param: str) -> str:
    return do_expensive_computation(param)

# Caching with TTL (1 hour)
@task(cache={'ttl': 3600})
def cached_task(ctx, name: str) -> dict:
    return fetch_data(name)

# Caching with ignored arguments
@task(cache={'ttl': 600, 'ignore_args': ['verbose']})
def cached_with_options(ctx, query: str, verbose: bool = False) -> list:
    return search(query, verbose=verbose)
```

## Installation

```bash
pip install invoke-toolkit[cache]
```

## Changes

- New `src/invoke_toolkit/tasks/cache.py` module
- Updated `@task` decorator with `cache` parameter
- Added `diskcache` as optional dependency (`[cache]` extra)
- 37 new tests for cache functionality
- Updated README with caching documentation

Closes #42