### PR TITLE
feat: suppress task name completion when completing positional args

### DIFF
--- a/src/invoke_toolkit/completion.py
+++ b/src/invoke_toolkit/completion.py
@@ -334,7 +334,7 @@ def _handle_positional_completion(
     collection,
     positional_index: int,
     incomplete: str = "",
-) -> bool:
+) -> tuple[bool, bool]:
     """
     Handle completion for positional arguments.
 
@@ -345,17 +345,22 @@ def _handle_positional_completion(
         incomplete: The incomplete value typed by user
 
     Returns:
-        True if choices were printed, False otherwise
+        Tuple of (handled, should_suppress_fallback):
+        - handled: True if choices were printed
+        - should_suppress_fallback: True if we're in a positional arg context
+          and should NOT fall back to task name completion
     """
     task_name = context.name
     if not task_name:
-        return False
+        return False, False
 
     # Get positional args from the context
     positional_args = context.positional_args
     if positional_index >= len(positional_args):
-        debug(f"Positional index {positional_index} out of range")
-        return False
+        debug(
+            f"Positional index {positional_index} out of range, allow task completion"
+        )
+        return False, False
 
     arg = positional_args[positional_index]
     arg_name: str = arg.name or ""
@@ -368,9 +373,12 @@ def _handle_positional_completion(
         debug(f"Found choices for {arg_name}: {choices[:10]}...")
         for choice in choices:
             print(choice)
-        return True
+        return True, True
 
-    return False
+    # No choices available, but we're still within positional args range
+    # Suppress fallback to task names - user needs to provide a value
+    debug(f"No completion for positional arg {arg_name}, suppressing task completion")
+    return False, True
 
 
 def complete_with_choices(
@@ -479,9 +487,12 @@ def complete_with_choices(
                     positional_index = max(0, positional_index - 1)
 
             # Try to complete positional argument
-            if _handle_positional_completion(
+            handled, suppress_fallback = _handle_positional_completion(
                 context, collection, positional_index, incomplete
-            ):
+            )
+            if handled or suppress_fallback:
+                # Either we printed completions, or we're in a positional arg
+                # that has no completion (like 'value') - don't show task names
                 raise Exit
 
         # Fall back to task name completion

--- a/tests/test_completion_with_choices.py
+++ b/tests/test_completion_with_choices.py
@@ -12,6 +12,7 @@ from invoke_toolkit import Context, task
 from invoke_toolkit.collections import ToolkitCollection
 from invoke_toolkit.completion import (
     _get_positional_arg_index,
+    _handle_positional_completion,
     get_choices_for_argument,
 )
 from invoke_toolkit.testing import TestingToolkitProgram
@@ -333,3 +334,82 @@ def test_completion_callback_priority_over_enum():
     # Ensure enum values are NOT returned (callback takes priority)
     assert "dev" not in lines, f"Unexpected enum value 'dev' in completion: {lines}"
     assert "prod" not in lines, f"Unexpected enum value 'prod' in completion: {lines}"
+
+
+def test_positional_completion_with_callback_returns_handled_and_suppress():
+    """Test that positional completion with callback returns (True, True)."""
+
+    def complete_paths(ctx: Context, incomplete: str) -> list[str]:
+        return ["run.echo", "run.warn"]
+
+    coll = ToolkitCollection()
+
+    @task
+    def get_value(
+        ctx: Context,
+        path: Annotated[str, complete_paths],
+    ) -> None:
+        """Get a value."""
+
+    coll.add_task(get_value)  # type: ignore[arg-type]
+
+    # Create a parser context for the task
+    ctx = ParserContext(name="get-value")
+    ctx.add_arg(Argument(names=("path",), positional=True))
+
+    # First positional arg (path) - has callback, should return (True, True)
+    handled, suppress = _handle_positional_completion(ctx, coll, 0, "")
+    assert handled is True, "Should have handled completion with callback"
+    assert suppress is True, "Should suppress fallback when handled"
+
+
+def test_positional_completion_without_callback_returns_not_handled_but_suppress():
+    """Test that positional completion without callback returns (False, True)."""
+    coll = ToolkitCollection()
+
+    @task
+    def set_value(
+        ctx: Context,
+        path: str,
+        value: str,  # No completion callback
+    ) -> None:
+        """Set a value."""
+
+    coll.add_task(set_value)  # type: ignore[arg-type]
+
+    # Create a parser context for the task
+    ctx = ParserContext(name="set-value")
+    ctx.add_arg(Argument(names=("path",), positional=True))
+    ctx.add_arg(Argument(names=("value",), positional=True))
+
+    # Second positional arg (value) - no callback, should return (False, True)
+    # to suppress task name completion
+    handled, suppress = _handle_positional_completion(ctx, coll, 1, "")
+    assert handled is False, "Should not have handled (no callback)"
+    assert suppress is True, (
+        "Should suppress fallback for positional arg without callback"
+    )
+
+
+def test_positional_completion_out_of_range_allows_task_completion():
+    """Test that completion after all positional args allows task names."""
+    coll = ToolkitCollection()
+
+    @task
+    def simple_task(
+        ctx: Context,
+        name: str,
+    ) -> None:
+        """A simple task."""
+
+    coll.add_task(simple_task)  # type: ignore[arg-type]
+
+    # Create a parser context for the task
+    ctx = ParserContext(name="simple-task")
+    ctx.add_arg(Argument(names=("name",), positional=True))
+
+    # Index 1 is out of range (only 1 positional arg at index 0)
+    # Should return (False, False) to allow task name completion
+    handled, suppress = _handle_positional_completion(ctx, coll, 1, "")
+    assert handled is False, "Should not have handled (out of range)"
+    assert suppress is False, "Should NOT suppress fallback when out of range"


### PR DESCRIPTION
## Summary

Follow-up to #52 - improves the completion behavior for positional arguments.

When completing positional arguments that don't have a completion callback (like the `value` argument in `config.set`), suppress the fallback to task name completion. This prevents showing irrelevant task names when the user needs to provide a free-form value.

## Behavior

| Command | Completion Result |
|---------|------------------|
| `intk -x config.set <TAB>` | Shows config paths (has callback) |
| `intk -x config.set path <TAB>` | Shows nothing (no callback for `value`) |
| `intk -x config.set path val <TAB>` | Shows task names (all positional args filled) |

## Changes

- `_handle_positional_completion` now returns `(handled, should_suppress)` tuple
- When within positional args range but no callback exists, suppress fallback
- Only allow task name completion when all positional args are filled
- Added tests for the new behavior

Related to #49