### PR TITLE
Fix basedpyright partially unknown type warnings for ctx.print and ctx.cd

### DIFF
--- a/src/invoke_toolkit/context/context.py
+++ b/src/invoke_toolkit/context/context.py
@@ -3,7 +3,8 @@
 import os
 import subprocess
 import sys
-from contextlib import contextmanager
+from contextlib import _GeneratorContextManager, contextmanager
+from os import PathLike
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -13,6 +14,7 @@ from typing import (
     NoReturn,
     Optional,
     Protocol,
+    Union,
 )
 
 import setproctitle
@@ -57,6 +59,11 @@ class ToolkitContext(Context, ConfigProtocol):
     _console: "Console"
     _config: ToolkitConfig
     _status_helper: StatusHelper
+
+    # Override cd with proper type annotation to fix PathLike[Unknown] issue
+    cd: Callable[
+        [Union[PathLike[str], str]], _GeneratorContextManager[None, None, None]
+    ]
 
     def __init__(self, config: Optional[ToolkitConfig] = None) -> None:
         super().__init__(config)


### PR DESCRIPTION
## Summary

This PR fixes the 'partially unknown' type warnings from basedpyright for `ctx.print` and `ctx.cd`.

## Changes

### `SecretRedactorConsole.print` (console.py)
- Added proper type annotations to match Rich's `Console.print` signature
- Explicitly pass all parameters to `super().print()` instead of using `**kwargs`
- Fixed variable shadowing where loop variables `end` and `style` were shadowing method parameters (renamed to `seg_end` and `seg_style`)
- Added pylint disable comment for `too-many-arguments` and `too-many-locals` since this is an override

### `ToolkitContext.cd` (context.py)
- Added properly typed `cd` attribute annotation to override the parent class's untyped `PathLike`
- The upstream invoke library uses `PathLike` without a type parameter, causing `PathLike[Unknown]` in inferred types

## Result
- `ctx.print` no longer shows 'partially unknown' warnings
- `ctx.cd` warnings reduced from 26 to 1 (the remaining one is in a test using plain `invoke.Context`)