### PR TITLE
feat: use ctx.print_err for fzf fallback messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ per-file-ignores = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=invoke_toolkit --html=report.html --self-contained-html"
+addopts = "--cov=invoke_toolkit --cov=tests --html=report.html --self-contained-html"
 filterwarnings = []
 
 [tool.pyright]

--- a/src/invoke_toolkit/utils/fzf.py
+++ b/src/invoke_toolkit/utils/fzf.py
@@ -41,14 +41,15 @@ def is_fzf_available() -> bool:
     return available
 
 
-def _show_fzf_warning(ctx: Context) -> None:
+def _show_fzf_warning(ctx: Context, force_fallback: bool = False) -> None:
     """
-    Show a warning message when fzf is not available.
+    Show a warning message when fzf is not available or disabled.
 
     Can be disabled via config: fuzzy_finder.show_warnings = False
 
     Args:
         ctx: The invoke context
+        force_fallback: Whether fallback is forced via config
     """
     global _fzf_warning_shown  # pylint: disable=global-statement
 
@@ -69,17 +70,21 @@ def _show_fzf_warning(ctx: Context) -> None:
 
     debug("Showing fzf warning message")
 
-    console = Console(stderr=True)
-    console.print(
-        "[yellow]Note:[/yellow] fzf not found. "
-        "For better interactive selection, install fzf: "
-        "[cyan]https://github.com/junegunn/fzf[/cyan]",
-        highlight=False,
-    )
-    console.print(
-        "[dim]Disable this message with config: fuzzy_finder.show_warnings = false[/dim]",
-        highlight=False,
-    )
+    if force_fallback:
+        ctx.print_err(
+            "[yellow]Note:[/yellow] fzf is disabled via config (force_fallback=true). "
+            "Using rich-based fallback selector."
+        )
+        ctx.print_err("[dim]Re-enable with: fuzzy_finder.force_fallback = false[/dim]")
+    else:
+        ctx.print_err(
+            "[yellow]Note:[/yellow] fzf not found. "
+            "For better interactive selection, install fzf: "
+            "[cyan]https://github.com/junegunn/fzf[/cyan]"
+        )
+        ctx.print_err(
+            "[dim]Disable this message with config: fuzzy_finder.show_warnings = false[/dim]"
+        )
 
     _fzf_warning_shown = True
 
@@ -366,9 +371,8 @@ def select(  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
             raise RuntimeError(
                 "fzf is not installed. Install from: https://github.com/junegunn/fzf"
             )
-        # Show warning message (once per session, configurable) only if fzf not available
-        if not force_fallback:
-            _show_fzf_warning(ctx)
+        # Show warning message (once per session, configurable)
+        _show_fzf_warning(ctx, force_fallback=force_fallback)
         # Use rich-based fallback with select_1 and exit_0 support
         select_1 = kwargs.get("select_1", False)
         exit_0 = kwargs.get("exit_0", False)
@@ -545,9 +549,8 @@ def select_from_command(  # pylint: disable=too-many-locals,too-many-branches,to
             raise RuntimeError(
                 "fzf is not installed. Install from: https://github.com/junegunn/fzf"
             )
-        # Show warning message (once per session, configurable) only if fzf not available
-        if not force_fallback:
-            _show_fzf_warning(ctx)
+        # Show warning message (once per session, configurable)
+        _show_fzf_warning(ctx, force_fallback=force_fallback)
         # Run command to get choices and use rich fallback
         debug(f"Running command to get choices: {command}")
         result = ctx.run(command, hide=True, warn=True)

--- a/tests/utils/test_fzf.py
+++ b/tests/utils/test_fzf.py
@@ -595,69 +595,59 @@ def test_select_from_command_with_select_1_uses_fallback_correctly():
 # Tests for fzf warning message
 
 
-def test_show_fzf_warning_displays_message():
+def test_show_fzf_warning_displays_message(capsys):
     """Test that warning message is displayed when fzf is not available."""
     ctx = Context()
 
-    with patch("invoke_toolkit.utils.fzf.Console") as mock_console_class:
-        mock_console = Mock()
-        mock_console_class.return_value = mock_console
+    # Reset the global warning flag
+    import invoke_toolkit.utils.fzf as fzf_module
 
-        # Reset the global warning flag
-        import invoke_toolkit.utils.fzf as fzf_module
+    fzf_module._fzf_warning_shown = False
 
-        fzf_module._fzf_warning_shown = False
+    _show_fzf_warning(ctx, force_fallback=False)
 
-        _show_fzf_warning(ctx)
-
-        # Should create console with stderr=True
-        mock_console_class.assert_called_once_with(stderr=True)
-
-        # Should print warning messages
-        assert mock_console.print.call_count == 2
-        first_call = mock_console.print.call_args_list[0][0][0]
-        assert "fzf not found" in first_call
-        assert "https://github.com/junegunn/fzf" in first_call
+    # Check stderr output
+    captured = capsys.readouterr()
+    assert "fzf not found" in captured.err
+    assert "https://github.com/junegunn/fzf" in captured.err
+    assert "fuzzy_finder.show_warnings = false" in captured.err
 
 
-def test_show_fzf_warning_only_shows_once():
+def test_show_fzf_warning_only_shows_once(capsys):
     """Test that warning is only shown once per session."""
     ctx = Context()
 
-    with patch("invoke_toolkit.utils.fzf.Console") as mock_console_class:
-        mock_console = Mock()
-        mock_console_class.return_value = mock_console
+    # Reset the global warning flag
+    import invoke_toolkit.utils.fzf as fzf_module
 
-        # Reset the global warning flag
-        import invoke_toolkit.utils.fzf as fzf_module
+    fzf_module._fzf_warning_shown = False
 
-        fzf_module._fzf_warning_shown = False
+    # Call twice
+    _show_fzf_warning(ctx, force_fallback=False)
+    _show_fzf_warning(ctx, force_fallback=False)
 
-        # Call multiple times
-        _show_fzf_warning(ctx)
-        _show_fzf_warning(ctx)
-        _show_fzf_warning(ctx)
-
-        # Should only create console once
-        mock_console_class.assert_called_once()
+    # Check that message only appears once
+    captured = capsys.readouterr()
+    # Count occurrences of the warning message
+    occurrences = captured.err.count("fzf not found")
+    assert occurrences == 1
 
 
-def test_show_fzf_warning_respects_config():
-    """Test that warning respects fuzzy_finder.show_warnings config."""
+def test_show_fzf_warning_respects_config(capsys):
+    """Test that warning can be disabled via config."""
     ctx = Context()
-    # Use merge_dicts to properly set nested config
     ctx.config._config["fuzzy_finder"] = {"show_warnings": False}
 
-    with patch("invoke_toolkit.utils.fzf.Console") as mock_console_class:
-        # Reset the global warning flag
-        import invoke_toolkit.utils.fzf as fzf_module
+    # Reset the global warning flag
+    import invoke_toolkit.utils.fzf as fzf_module
 
-        fzf_module._fzf_warning_shown = False
+    fzf_module._fzf_warning_shown = False
 
-        _show_fzf_warning(ctx)
+    _show_fzf_warning(ctx, force_fallback=False)
 
-        # Should not create console or print anything
-        mock_console_class.assert_not_called()
+    # Should not output anything when warnings disabled
+    captured = capsys.readouterr()
+    assert captured.err == ""
 
 
 def test_select_shows_warning_when_using_fallback():
@@ -675,7 +665,7 @@ def test_select_shows_warning_when_using_fallback():
                 select(ctx, ["option1", "option2"], use_fallback=True)
 
                 # Should call warning function
-                mock_warning.assert_called_once_with(ctx)
+                mock_warning.assert_called_once_with(ctx, force_fallback=False)
 
 
 def test_select_from_command_shows_warning_when_using_fallback():
@@ -699,7 +689,7 @@ def test_select_from_command_shows_warning_when_using_fallback():
                     select_from_command(ctx, "echo test", use_fallback=True)
 
                     # Should call warning function
-                    mock_warning.assert_called_once_with(ctx)
+                    mock_warning.assert_called_once_with(ctx, force_fallback=False)
 
 
 def test_warning_not_shown_when_fzf_available():
@@ -732,8 +722,8 @@ def test_select_respects_force_fallback_config():
 
                 # Should use rich fallback even though fzf is available
                 mock_rich.assert_called_once()
-                # Should not show warning when force_fallback is enabled
-                mock_warning.assert_not_called()
+                # Should show warning with force_fallback=True
+                mock_warning.assert_called_once_with(ctx, force_fallback=True)
                 assert result == "option1"
 
 
@@ -756,8 +746,8 @@ def test_select_from_command_respects_force_fallback_config():
 
                     # Should use rich fallback even though fzf is available
                     mock_rich.assert_called_once()
-                    # Should not show warning when force_fallback is enabled
-                    mock_warning.assert_not_called()
+                    # Should show warning with force_fallback=True
+                    mock_warning.assert_called_once_with(ctx, force_fallback=True)
                     assert result == "option2"
 
 
@@ -790,7 +780,7 @@ def test_select_respects_force_fallback_env_var():
 
                     assert result == "option1"
                     mock_rich.assert_called_once()
-                    mock_warning.assert_not_called()
+                    mock_warning.assert_called_once_with(ctx, force_fallback=True)
 
 
 def test_select_from_command_respects_force_fallback_env_var():
@@ -821,7 +811,7 @@ def test_select_from_command_respects_force_fallback_env_var():
 
                         assert result == "option1"
                         mock_rich.assert_called_once()
-                        mock_warning.assert_not_called()
+                        mock_warning.assert_called_once_with(ctx, force_fallback=True)
 
 
 def test_env_var_overrides_config():
@@ -846,4 +836,4 @@ def test_env_var_overrides_config():
 
                     assert result == "option1"
                     mock_rich.assert_called_once()
-                    mock_warning.assert_not_called()
+                    mock_warning.assert_called_once_with(ctx, force_fallback=True)


### PR DESCRIPTION
## Summary

Improves fzf fallback messaging by using `ctx.print_err` instead of directly creating a Console instance, and adds informative messages when fallback is forced via config.

## Changes

1. **Use `ctx.print_err` for consistency**: 
   - Replaces `Console(stderr=True)` with `ctx.print_err()`
   - More consistent with the toolkit's context-based approach

2. **Add informative message for `force_fallback`**:
   - When `force_fallback=true` is set, users now see:
     ```
     Note: fzf is disabled via config (force_fallback=true). Using rich-based fallback selector.
     Re-enable with: fuzzy_finder.force_fallback = false
     ```
   - Helps users understand why fzf isn't being used even when installed

3. **Update tests**:
   - Capture stderr output using `capsys` fixture
   - Update all test expectations for the new parameter signature
   - All 55 tests passing

4. **Add test coverage measurement**:
   - Configure pytest to measure test code coverage as well
   - Helps identify untested code paths in test files

## Testing

- All 55 fzf tests pass
- Pre-commit checks pass
- Messages tested manually for both scenarios (fzf not found vs. disabled)

## Example Output

**When fzf is not installed:**
```
Note: fzf not found. For better interactive selection, install fzf: https://github.com/junegunn/fzf
Disable this message with config: fuzzy_finder.show_warnings = false
```

**When force_fallback is enabled:**
```
Note: fzf is disabled via config (force_fallback=true). Using rich-based fallback selector.
Re-enable with: fuzzy_finder.force_fallback = false
```