### PR TITLE
feat: add ctx.get_config_value() method and fix completion config

### DIFF
--- a/src/invoke_toolkit/completion.py
+++ b/src/invoke_toolkit/completion.py
@@ -20,7 +20,7 @@ from invoke.completion.complete import (
 from invoke.exceptions import Exit, ParseError
 from invoke.parser import Parser, ParserContext
 
-from invoke_toolkit.config import get_config_value
+from invoke_toolkit.config import ToolkitConfig
 from invoke_toolkit.context import ToolkitContext
 from invoke_toolkit.tasks.tasks import (
     _extract_enum_params,
@@ -176,11 +176,11 @@ def get_choices_for_argument(
         if arg_name in callbacks:
             try:
                 # Try to call the callback with context and incomplete
-                ctx = ToolkitContext()
+                ctx = ToolkitContext(config=ToolkitConfig())
 
                 # Get timeout from config (default: 10 seconds)
-                timeout = get_config_value(
-                    ctx, "completion.callback_timeout", default=10.0
+                timeout = ctx.get_config_value(
+                    "completion.callback_timeout", default=10.0
                 )
 
                 # Execute callback with timeout

--- a/src/invoke_toolkit/config/config.py
+++ b/src/invoke_toolkit/config/config.py
@@ -391,32 +391,30 @@ def get_config_value(  # pylint: disable=inconsistent-return-statements
         SystemExit: Raised via ctx.rich_exit() if required value is missing.
 
     Examples:
-        >>> from invoke_toolkit import task, Context
-        >>> from invoke_toolkit.config import get_config_value
-        >>> @task()
-        >>> def my_task(ctx: Context, db_host: str = "") -> None:
-        >>>     # Simple usage
-        >>>     db_host = db_host or get_config_value(
-        >>>         ctx, "database.host", default="localhost"
-        >>>     )
-        >>>
-        >>>     # With nested path and default
-        >>>     db_port = get_config_value(
-        >>>         ctx, "database.settings.port", default=5432
-        >>>     )
-        >>>
-        >>>     # Required value with custom message
-        >>>     api_key = get_config_value(
-        >>>         ctx, "api.key",
-        >>>         exit_code=2,
-        >>>         exit_message="API key must be configured in 'api.key'"
-        >>>     )
-        >>>
-        >>>     # Required value with auto-detected argument name
-        >>>     secret = get_config_value(
-        >>>         ctx, "secrets.token",
-        >>>         exit_code=1  # Auto-detects 'secret' parameter name
-        >>>     )
+        Preferred: Use the context method (no import needed)::
+
+            @task()
+            def my_task(ctx: Context) -> None:
+                # Simple usage with default
+                db_host = ctx.get_config_value("database.host", default="localhost")
+
+                # Required value - exits if missing
+                api_key = ctx.get_config_value("api.key", required=True)
+
+                # Required with custom exit code and message
+                secret = ctx.get_config_value(
+                    "secrets.token",
+                    exit_code=2,
+                    exit_message="Token must be configured"
+                )
+
+        Alternative: Use the standalone function (backward compatible)::
+
+            from invoke_toolkit.config import get_config_value
+
+            @task()
+            def my_task(ctx: Context) -> None:
+                db_host = get_config_value(ctx, "database.host", default="localhost")
     """
     # Mark as required if exit parameters are provided or if required=True
     has_exit_params = (exit_message is not None) or (exit_code is not None) or required

--- a/src/invoke_toolkit/context/context.py
+++ b/src/invoke_toolkit/context/context.py
@@ -7,6 +7,7 @@ from contextlib import _GeneratorContextManager, contextmanager
 from os import PathLike
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Generator,
     Iterator,
@@ -16,6 +17,7 @@ from typing import (
     Protocol,
     TypeVar,
     Union,
+    overload,
 )
 
 import setproctitle
@@ -329,3 +331,87 @@ class ToolkitContext(Context, ConfigProtocol):
                     ["tmux", "rename-window", previous_tmux_title],
                     check=False,
                 )
+
+    # Type overloads for get_config_value - returns T when no exit params
+    @overload
+    def get_config_value(
+        self,
+        path: str,
+        default: T = ...,  # type: ignore[assignment]
+        exit_message: None = None,
+        exit_code: None = None,
+        required: bool = False,
+    ) -> Any | T: ...
+
+    # Type hints NoReturn when exit_message provided
+    @overload
+    def get_config_value(
+        self,
+        path: str,
+        default: Any = ...,
+        exit_message: str = ...,
+        exit_code: Optional[int] = None,
+        required: bool = False,
+    ) -> Any | NoReturn: ...
+
+    # Type hints NoReturn when exit_code provided
+    @overload
+    def get_config_value(
+        self,
+        path: str,
+        default: Any = ...,
+        exit_message: None = None,
+        exit_code: int = ...,
+        required: bool = False,
+    ) -> Any | NoReturn: ...
+
+    # Type hints NoReturn when required=True
+    @overload
+    def get_config_value(
+        self,
+        path: str,
+        default: Any = ...,
+        exit_message: Optional[str] = None,
+        exit_code: Optional[int] = None,
+        required: bool = True,
+    ) -> Any | NoReturn: ...
+
+    def get_config_value(
+        self,
+        path: str,
+        default: Any = ...,
+        exit_message: Optional[str] = None,
+        exit_code: Optional[int] = None,
+        required: bool = False,
+    ) -> Any:
+        """Get a configuration value from config with dot notation support.
+
+        This is a convenience method that wraps invoke_toolkit.config.get_config_value.
+        See that function for full documentation.
+
+        Args:
+            path: Dot-separated path to the config value (e.g., 'database.host')
+            default: Default value if path not found
+            exit_message: Custom message when value required but missing
+            exit_code: Exit code for ctx.rich_exit() when missing
+            required: Whether value is required (exits if missing)
+
+        Returns:
+            The config value if found, otherwise default value.
+
+        Example:
+            @task()
+            def my_task(ctx: Context) -> None:
+                db_host = ctx.get_config_value("database.host", default="localhost")
+                api_key = ctx.get_config_value("api.key", required=True)
+        """
+        # Import here to avoid circular imports
+        from invoke_toolkit.config.config import (  # pylint: disable=import-outside-toplevel
+            _UNDEFINED_DEFAULT,
+            get_config_value as _get_config_value,
+        )
+
+        # Handle the default sentinel - ellipsis means "use undefined default"
+        if default is ...:
+            default = _UNDEFINED_DEFAULT
+        return _get_config_value(self, path, default, exit_message, exit_code, required)

--- a/src/invoke_toolkit/extensions/tasks/config.py
+++ b/src/invoke_toolkit/extensions/tasks/config.py
@@ -404,10 +404,8 @@ def _complete_config_path(ctx: Context, incomplete: str) -> list[str]:
 
         def _complete_my_items(ctx: Context, incomplete: str) -> list[str]:
             '''Completion callback for my custom items.'''
-            from invoke_toolkit.config import get_config_value
-
-            # Get data from context or config
-            items = get_config_value(ctx, "my.items", default=[])
+            # Get data from config using context method (no import needed)
+            items = ctx.get_config_value("my.items", default=[])
 
             # Filter by incomplete prefix
             matching = [i for i in items if i.startswith(incomplete)]

--- a/tests/test_completion_with_choices.py
+++ b/tests/test_completion_with_choices.py
@@ -1126,3 +1126,47 @@ def test_completion_callback_cached_decorator_without_diskcache():
     # Check cache info shows no backend
     cache_info = no_cache_callback.cache_info()
     assert cache_info["backend"] == "none"
+
+
+def test_completion_callback_has_access_to_config():
+    """Test that completion callbacks have access to ToolkitConfig.
+
+    This test demonstrates that the fix for instantiating ToolkitConfig in completion
+    callbacks allows them to access the config object and read config values like
+    completion.callback_timeout with the correct defaults.
+
+    Before the fix, ctx.get_config_value() would only return default values because
+    ToolkitContext was instantiated without any config, causing it to use the
+    base invoke.config.Config instead of ToolkitConfig.
+    """
+
+    def config_aware_callback(ctx: Context, incomplete: str) -> list[str]:
+        """A callback that reads config values."""
+        # Uses ctx.get_config_value() method - no import needed
+        # This works because ctx has ToolkitConfig (not base Config)
+        timeout = ctx.get_config_value("completion.callback_timeout", default=999.0)
+
+        # With the fix, this should be 10.0 (the ToolkitConfig default)
+        # Without the fix, it would fall back to the default value (999.0)
+        return [f"timeout={timeout}"]
+
+    coll = ToolkitCollection()
+
+    @task
+    def config_task(
+        ctx: Context,
+        option: Annotated[str, config_aware_callback],
+    ) -> None:
+        """Task that uses config in completion callback."""
+
+    coll.add_task(config_task)  # type: ignore[arg-type]
+
+    # Get completion choices
+    choices = get_choices_for_argument(coll, "config-task", "option", "")
+
+    # Verify the callback could access the ToolkitConfig default value
+    assert len(choices) == 1, f"Expected 1 choice, got {len(choices)}: {choices}"
+    # Should be the ToolkitConfig default (10.0), not the fallback default (999.0)
+    assert "timeout=10.0" in choices, (
+        f"Expected default timeout value (10.0) from ToolkitConfig, got: {choices}"
+    )

--- a/tests/test_config_helper.py
+++ b/tests/test_config_helper.py
@@ -1,11 +1,17 @@
-"""Tests for config helper functions"""
+"""Tests for config helper functions
+
+NOTE: These tests use ctx.get_config_value() method instead of the standalone
+get_config_value() function. The standalone function remains available for
+backward compatibility but the method is the preferred API. The method
+delegates to the standalone function, so these tests validate both.
+"""
 
 from typing import cast
 
 import pytest
 
 from invoke_toolkit import Context
-from invoke_toolkit.config import ToolkitConfig, get_config_value
+from invoke_toolkit.config import ToolkitConfig
 
 
 @pytest.fixture
@@ -41,65 +47,63 @@ def ctx():
 # Basic path retrieval tests
 def test_get_config_value_simple_path(ctx):
     """Test retrieval with simple single-level path"""
-    result = get_config_value(ctx, "database.host")
+    result = ctx.get_config_value("database.host")
     assert result == "localhost"
 
 
 def test_get_config_value_nested_path(ctx):
     """Test retrieval with nested path"""
-    result = get_config_value(ctx, "database.settings.port")
+    result = ctx.get_config_value("database.settings.port")
     assert result == 5432
 
 
 def test_get_config_value_deep_nested_path(ctx):
     """Test retrieval with deeply nested path"""
-    result = get_config_value(ctx, "api.endpoints.v1.base")
+    result = ctx.get_config_value("api.endpoints.v1.base")
     assert result == "https://api.example.com/v1"
 
 
 # Default value tests
 def test_get_config_value_missing_key_returns_default(ctx):
     """Test that default is returned when key is missing"""
-    result = get_config_value(ctx, "database.missing", default="default_value")
+    result = ctx.get_config_value("database.missing", default="default_value")
     assert result == "default_value"
 
 
 def test_get_config_value_missing_group_returns_default(ctx):
     """Test that default is returned when group is missing"""
-    result = get_config_value(ctx, "missing.key", default="default_value")
+    result = ctx.get_config_value("missing.key", default="default_value")
     assert result == "default_value"
 
 
 def test_get_config_value_missing_nested_returns_default(ctx):
     """Test that default is returned when nested path is incomplete"""
-    result = get_config_value(
-        ctx, "database.settings.missing.nested", default="default"
-    )
+    result = ctx.get_config_value("database.settings.missing.nested", default="default")
     assert result == "default"
 
 
 def test_get_config_value_returns_none_by_default(ctx):
     """Test that None is returned as default when not specified"""
-    result = get_config_value(ctx, "missing.path")
+    result = ctx.get_config_value("missing.path")
     assert result is None
 
 
 # Special value tests
 def test_get_config_value_with_empty_string(ctx):
     """Test that empty string is returned correctly (not treated as missing)"""
-    result = get_config_value(ctx, "feature.name", default="default_value")
+    result = ctx.get_config_value("feature.name", default="default_value")
     assert result == ""
 
 
 def test_get_config_value_with_boolean_false(ctx):
     """Test that False is returned correctly (not treated as missing)"""
-    result = get_config_value(ctx, "feature.enabled", default=True)
+    result = ctx.get_config_value("feature.enabled", default=True)
     assert result is False
 
 
 def test_get_config_value_with_zero(ctx):
     """Test that 0 is returned correctly (not treated as missing)"""
-    result = get_config_value(ctx, "feature.retry_count", default=42)
+    result = ctx.get_config_value("feature.retry_count", default=42)
     assert result == 0
 
 
@@ -107,13 +111,13 @@ def test_get_config_value_with_zero(ctx):
 def test_get_config_value_required_with_exit_code_missing(ctx):
     """Test that required value with exit_code exits when missing"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(ctx, "missing.required", exit_code=2)
+        ctx.get_config_value("missing.required", exit_code=2)
     assert cast(SystemExit, exc_info.value).code == 2
 
 
 def test_get_config_value_required_with_exit_code_found(ctx):
     """Test that required value with exit_code returns value when found"""
-    result = get_config_value(ctx, "database.host", exit_code=1)
+    result = ctx.get_config_value("database.host", exit_code=1)
     assert result == "localhost"
 
 
@@ -121,8 +125,7 @@ def test_get_config_value_required_with_exit_code_found(ctx):
 def test_get_config_value_required_with_exit_message(ctx):
     """Test that required value with exit_message exits when missing"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(
-            ctx,
+        ctx.get_config_value(
             "missing.value",
             exit_message="Custom error message",
             exit_code=3,
@@ -132,8 +135,7 @@ def test_get_config_value_required_with_exit_message(ctx):
 
 def test_get_config_value_required_with_exit_message_found(ctx):
     """Test that exit_message doesn't trigger when value is found"""
-    result = get_config_value(
-        ctx,
+    result = ctx.get_config_value(
         "database.host",
         exit_message="This should not appear",
         exit_code=1,
@@ -145,14 +147,14 @@ def test_get_config_value_required_with_exit_message_found(ctx):
 def test_get_config_value_required_true_exits(ctx):
     """Test that required=True triggers exit with code 1"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(ctx, "missing.key", required=True)
+        ctx.get_config_value("missing.key", required=True)
     assert cast(SystemExit, exc_info.value).code == 1
 
 
 def test_get_config_value_required_with_exit_code_default_code(ctx):
     """Test that default exit_code is 1 when exit_code not specified"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(ctx, "missing.value", exit_message="Error")
+        ctx.get_config_value("missing.value", exit_message="Error")
     assert cast(SystemExit, exc_info.value).code == 1
 
 
@@ -163,30 +165,30 @@ def test_get_config_value_single_key_path(ctx):
     ctx_simple = Context(config=config)
     # Note: This should return None since 'simple_key' is at the root level
     # and we're looking for 'simple_key.subkey'
-    result = get_config_value(ctx_simple, "simple_key.subkey", default="default")
+    result = ctx_simple.get_config_value("simple_key.subkey", default="default")
     assert result == "default"
 
 
 def test_get_config_value_complex_nested_structure(ctx):
     """Test with complex nested structures"""
-    result = get_config_value(ctx, "api.endpoints.v1.base")
+    result = ctx.get_config_value("api.endpoints.v1.base")
     assert result == "https://api.example.com/v1"
 
 
 def test_get_config_value_preserves_data_types(ctx):
     """Test that data types are preserved"""
     # Integer
-    result = get_config_value(ctx, "database.settings.timeout")
+    result = ctx.get_config_value("database.settings.timeout")
     assert result == 30
     assert isinstance(result, int)
 
     # String
-    result = get_config_value(ctx, "database.host")
+    result = ctx.get_config_value("database.host")
     assert result == "localhost"
     assert isinstance(result, str)
 
     # Boolean
-    result = get_config_value(ctx, "feature.enabled")
+    result = ctx.get_config_value("feature.enabled")
     assert result is False
     assert isinstance(result, bool)
 
@@ -195,7 +197,7 @@ def test_get_config_value_preserves_data_types(ctx):
 def test_get_config_value_exit_code_without_message(ctx):
     """Test that exit_code without message auto-generates message"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(ctx, "missing.config", exit_code=5)
+        ctx.get_config_value("missing.config", exit_code=5)
     assert cast(SystemExit, exc_info.value).code == 5
 
 
@@ -204,7 +206,7 @@ def test_get_config_value_returns_none_when_explicitly_set(ctx):
     """Test that None from config is returned correctly (not replaced with default)"""
     config = ToolkitConfig(overrides={"nullable": {"value": None}})
     ctx_none = Context(config=config)
-    result = get_config_value(ctx_none, "nullable.value", default="default")
+    result = ctx_none.get_config_value("nullable.value", default="default")
     assert result is None
 
 
@@ -216,15 +218,15 @@ def test_get_config_value_undefined_vs_none_difference():
     ctx_test = Context(config=config)
 
     # Missing value with no default returns None
-    result1 = get_config_value(ctx_test, "data.not_there")
+    result1 = ctx_test.get_config_value("data.not_there")
     assert result1 is None
 
     # Explicitly set None in config should be returned as-is
-    result2 = get_config_value(ctx_test, "data.explicit_none", default="default")
+    result2 = ctx_test.get_config_value("data.explicit_none", default="default")
     assert result2 is None
 
     # Provide an explicit None as default
-    result3 = get_config_value(ctx_test, "data.not_there_either", default=None)
+    result3 = ctx_test.get_config_value("data.not_there_either", default=None)
     assert result3 is None
 
 
@@ -232,7 +234,7 @@ def test_get_config_value_with_explicit_none_default():
     """Test that explicitly passing None as default works"""
     config = ToolkitConfig(overrides={"some": {"value": "data"}})
     ctx_test = Context(config=config)
-    result = get_config_value(ctx_test, "missing.key", default=None)
+    result = ctx_test.get_config_value("missing.key", default=None)
     assert result is None
 
 
@@ -242,30 +244,28 @@ def test_get_config_value_distinguishes_missing_from_none():
     ctx_test = Context(config=config)
 
     # Config value that is explicitly None
-    timeout = get_config_value(ctx_test, "db.timeout", default=30)
+    timeout = ctx_test.get_config_value("db.timeout", default=30)
     assert timeout is None
 
     # Missing value should use the default
-    pool_size = get_config_value(ctx_test, "db.pool_size", default=10)
+    pool_size = ctx_test.get_config_value("db.pool_size", default=10)
     assert pool_size == 10
 
     # Retries value (not None)
-    retries = get_config_value(ctx_test, "db.retries", default=5)
+    retries = ctx_test.get_config_value("db.retries", default=5)
     assert retries == 3
 
 
 def test_get_config_value_required_true_found(ctx):
     """Test that required=True returns value when found"""
-    result = get_config_value(ctx, "database.host", required=True)
+    result = ctx.get_config_value("database.host", required=True)
     assert result == "localhost"
 
 
 def test_get_config_value_required_true_with_default_ignored(ctx):
     """Test that required=True ignores default and exits when not found"""
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(
-            ctx, "missing.key", required=True, default="should_not_be_used"
-        )
+        ctx.get_config_value("missing.key", required=True, default="should_not_be_used")
     assert cast(SystemExit, exc_info.value).code == 1
 
 
@@ -289,7 +289,7 @@ def test_get_config_value_auto_detected_name_in_error():
 
     # When a value is not found with exit_code, should get auto-detected message
     with pytest.raises(SystemExit) as exc_info:
-        get_config_value(ctx, "database.host", exit_code=1)
+        ctx.get_config_value("database.host", exit_code=1)
     assert cast(SystemExit, exc_info.value).code == 1
 
 
@@ -298,5 +298,39 @@ def test_get_config_value_handles_path_with_multiple_components():
     config = ToolkitConfig(overrides={"deep": {"nested": {"value": {"here": "found"}}}})
     ctx = Context(config=config)
 
-    result = get_config_value(ctx, "deep.nested.value.here")
+    result = ctx.get_config_value("deep.nested.value.here")
     assert result == "found"
+
+
+# Tests for ctx.get_config_value() method specifically
+def test_ctx_get_config_value_method_exists():
+    """Test that ToolkitContext has the get_config_value method."""
+    ctx = Context(config=ToolkitConfig())
+    assert hasattr(ctx, "get_config_value")
+    assert callable(ctx.get_config_value)
+
+
+def test_ctx_get_config_value_delegates_to_function():
+    """Test that method produces same results as standalone function."""
+    from invoke_toolkit.config import get_config_value as standalone_fn
+
+    config = ToolkitConfig(overrides={"test": {"value": "data"}})
+    ctx = Context(config=config)
+
+    method_result = ctx.get_config_value("test.value", default="fallback")
+    function_result = standalone_fn(ctx, "test.value", default="fallback")
+
+    assert method_result == function_result == "data"
+
+
+def test_ctx_get_config_value_with_all_parameters():
+    """Test method works with all parameter combinations."""
+    config = ToolkitConfig(overrides={"db": {"host": "localhost"}})
+    ctx = Context(config=config)
+
+    # With default
+    assert ctx.get_config_value("db.host", default="127.0.0.1") == "localhost"
+    assert ctx.get_config_value("missing", default="fallback") == "fallback"
+
+    # With required=True (found)
+    assert ctx.get_config_value("db.host", required=True) == "localhost"


### PR DESCRIPTION
## Summary

This PR addresses two related improvements to the config system:

### 1. Fix Autocompletion Config Instantiation

- **Problem**: Completion callbacks were not receiving properly instantiated `ToolkitConfig`, causing `get_config_value()` to only return default values
- **Solution**: Updated `completion.py` to instantiate `ToolkitContext(config=ToolkitConfig())` instead of `ToolkitContext()`
- **Impact**: Users can now customize completion behavior via config files (user, system, or project-level)

### 2. Add `get_config_value()` Method to `ToolkitContext`

- **Goal**: Reduce imports by allowing `ctx.get_config_value()` instead of importing the standalone function
- **Implementation**: Method delegates to the standalone function (fully backward compatible)
- **Features**:
  - Full type overloads for IDE support
  - Same signature as standalone function
  - Updated all tests to use the new pattern
  - Added 3 dedicated tests for the method

## Usage

**Before (still works):**
```python
from invoke_toolkit.config import get_config_value

@task()
def my_task(ctx: Context) -> None:
    db_host = get_config_value(ctx, "database.host", default="localhost")
```

**After (preferred):**
```python
@task()
def my_task(ctx: Context) -> None:
    db_host = ctx.get_config_value("database.host", default="localhost")
```

## Files Changed

| File | Changes |
|------|---------|
| `src/invoke_toolkit/context/context.py` | Added `get_config_value` method with 4 type overloads |
| `src/invoke_toolkit/completion.py` | Fixed config instantiation, updated to use new method |
| `src/invoke_toolkit/config/config.py` | Updated docstring examples |
| `src/invoke_toolkit/extensions/tasks/config.py` | Updated docstring example |
| `tests/test_completion_with_choices.py` | Updated test to use new pattern |
| `tests/test_config_helper.py` | Updated all tests + added 3 new method tests |

## Breaking Changes

None. The standalone `get_config_value()` function remains available for backward compatibility.

## Related Issues

- Fixes #TBD (Autocompletion config not instantiated)
- Closes #TBD (Add ctx.get_config_value() method)