### PR TITLE
feat: thread loaded config into completion callbacks (closes #95)

### DIFF
--- a/src/invoke_toolkit/completion.py
+++ b/src/invoke_toolkit/completion.py
@@ -143,7 +143,11 @@ def _get_file_completions(
 
 
 def get_choices_for_argument(
-    collection, context_name: str, arg_name: str, incomplete: str = ""
+    collection,
+    context_name: str,
+    arg_name: str,
+    incomplete: str = "",
+    config: "ToolkitConfig | None" = None,
 ) -> List[str]:
     """
     Get available choices for an argument in a task.
@@ -159,6 +163,10 @@ def get_choices_for_argument(
         context_name: The task name
         arg_name: The argument name (without dashes)
         incomplete: The incomplete value typed by user (for callback filtering)
+        config: Optional already-loaded ToolkitConfig (e.g. from the program).
+                When provided the callbacks receive a context backed by this
+                config so project-level invoke.yaml values are visible.
+                Falls back to a fresh ToolkitConfig() when omitted.
 
     Returns:
         List of choice strings, or empty list if no choices defined
@@ -175,8 +183,12 @@ def get_choices_for_argument(
         callbacks = task._completion_callbacks  # pylint: disable=protected-access
         if arg_name in callbacks:
             try:
-                # Try to call the callback with context and incomplete
-                ctx = ToolkitContext(config=ToolkitConfig())
+                # Use the provided config (with project values loaded) or fall
+                # back to a plain ToolkitConfig so at least built-in defaults
+                # are available.
+                ctx = ToolkitContext(
+                    config=config if config is not None else ToolkitConfig()
+                )
 
                 # Get timeout from config (default: 10 seconds)
                 timeout = ctx.get_config_value(
@@ -331,6 +343,7 @@ def _handle_flag_completion(
     flag_name: str,
     collection,
     incomplete: str = "",
+    config: "ToolkitConfig | None" = None,
 ) -> bool:
     """
     Handle completion for a flag that takes a value.
@@ -340,6 +353,7 @@ def _handle_flag_completion(
         flag_name: The flag name (e.g., '--color')
         collection: The invoke collection
         incomplete: The incomplete value typed by user
+        config: Optional already-loaded ToolkitConfig forwarded to callbacks.
 
     Returns:
         True if choices were printed, False otherwise
@@ -370,7 +384,9 @@ def _handle_flag_completion(
     task_name = context.name
 
     if task_name:
-        choices = get_choices_for_argument(collection, task_name, arg_name, incomplete)
+        choices = get_choices_for_argument(
+            collection, task_name, arg_name, incomplete, config=config
+        )
         if choices:
             debug(f"Found choices for {arg_name}: {choices}")
             for choice in choices:
@@ -387,6 +403,7 @@ def _try_complete_flag_value(
     completing_new_token: bool,
     initial_context: ParserContext,
     collection,
+    config: "ToolkitConfig | None" = None,
 ) -> bool:
     """
     Try to complete a value for a flag that takes a value.
@@ -396,6 +413,7 @@ def _try_complete_flag_value(
         completing_new_token: Whether we're completing a new token (trailing space)
         initial_context: The core context with flag definitions
         collection: The invoke collection
+        config: Optional already-loaded ToolkitConfig forwarded to callbacks.
 
     Returns:
         True if completion was handled, False otherwise
@@ -418,7 +436,9 @@ def _try_complete_flag_value(
     # We're completing a value for this flag
     incomplete = tokens[-1] if not completing_new_token else ""
     debug(f"Completing value for flag {prev_token}, incomplete={incomplete!r}")
-    return _handle_flag_completion(initial_context, prev_token, collection, incomplete)
+    return _handle_flag_completion(
+        initial_context, prev_token, collection, incomplete, config=config
+    )
 
 
 def _get_positional_arg_index(context: ParserContext, tokens: List[str]) -> int:
@@ -474,6 +494,7 @@ def _handle_positional_completion(
     collection,
     positional_index: int,
     incomplete: str = "",
+    config: "ToolkitConfig | None" = None,
 ) -> tuple[bool, bool]:
     """
     Handle completion for positional arguments.
@@ -483,6 +504,7 @@ def _handle_positional_completion(
         collection: The invoke collection
         positional_index: Which positional argument we're completing (0-based)
         incomplete: The incomplete value typed by user
+        config: Optional already-loaded ToolkitConfig forwarded to callbacks.
 
     Returns:
         Tuple of (handled, should_suppress_fallback):
@@ -508,7 +530,9 @@ def _handle_positional_completion(
     debug(f"Completing positional arg {positional_index}: {arg_name}")
 
     # Try to get choices for this argument
-    choices = get_choices_for_argument(collection, task_name, arg_name, incomplete)
+    choices = get_choices_for_argument(
+        collection, task_name, arg_name, incomplete, config=config
+    )
     if choices:
         debug(f"Found choices for {arg_name}: {choices[:10]}...")
         for choice in choices:
@@ -527,12 +551,24 @@ def complete_with_choices(
     initial_context: ParserContext,
     collection,
     parser: Parser,
+    config: "ToolkitConfig | None" = None,
 ) -> Exit:
     """
     Enhanced completion function that supports Enum and Literal choices.
 
     This function extends invoke's basic completion to handle completing
     argument values for parameters with defined choices, including positional arguments.
+
+    Args:
+        names: Binary names for stripping the program name from the invocation.
+        core: The core parse result (provides remainder).
+        initial_context: The core ParserContext with global flags.
+        collection: The loaded task collection.
+        parser: A fresh Parser instance for re-parsing the invocation.
+        config: The already-loaded ToolkitConfig from the program.  When
+                provided, completion callbacks receive a context that has
+                access to project-level invoke.yaml values (e.g. custom keys
+                and overridden ``completion.callback_timeout``).
     """
     # Strip out program name
     invocation = _strip_program_name(names, core.remainder)
@@ -585,12 +621,14 @@ def complete_with_choices(
                     print(name)
         # Known flags complete w/ values or nothing
         else:
-            _handle_flag_completion(context, tail, collection, incomplete="")
+            _handle_flag_completion(
+                context, tail, collection, incomplete="", config=config
+            )
     # If not a flag, check if we're completing a flag value, positional args, or task names
     else:
         # Check if the previous token is a flag that takes a value
         if _try_complete_flag_value(
-            tokens, completing_new_token, initial_context, collection
+            tokens, completing_new_token, initial_context, collection, config=config
         ):
             raise Exit
 
@@ -634,7 +672,7 @@ def complete_with_choices(
 
             # Try to complete positional argument
             handled, suppress_fallback = _handle_positional_completion(
-                context, collection, positional_index, incomplete
+                context, collection, positional_index, incomplete, config=config
             )
             if handled or suppress_fallback:
                 # Either we printed completions, or we're in a positional arg

--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -591,6 +591,7 @@ class ToolkitProgram(Program):
                 # NOTE: can't reuse self.parser as it has likely been mutated
                 # between when it was set and now.
                 parser=self._make_parser(),
+                config=self.config if isinstance(self.config, ToolkitConfig) else None,
             )
 
         # Fallback behavior if no tasks were given & no default specified

--- a/tests/examples/completion_with_config/.gitignore
+++ b/tests/examples/completion_with_config/.gitignore
@@ -1,0 +1,2 @@
+# Track the example invoke.yaml even though the root .gitignore excludes it.
+!invoke.yaml

--- a/tests/examples/completion_with_config/invoke.yaml
+++ b/tests/examples/completion_with_config/invoke.yaml
@@ -1,0 +1,22 @@
+# Example invoke.yaml for the completion_with_config example.
+#
+# Place this file next to tasks.py so invoke picks it up automatically
+# when running from this directory, or use --search-root to point to it:
+#
+#   intk --search-root tests/examples/completion_with_config deploy --target <TAB>
+#   intk --search-root tests/examples/completion_with_config deploy --env <TAB>
+#
+# Edit allowed_envs below and re-run tab-completion to see the suggestions change.
+
+# Controls how long a completion callback may run before it is abandoned.
+# Increase this if your callback fetches data from a slow remote API.
+completion:
+  callback_timeout: 5.0 # default: 10.0
+
+# Custom section read by complete_targets() and complete_environments() in tasks.py.
+# List only the environments whose targets should appear in tab-completion.
+# Remove or comment out allowed_envs to show targets from all environments.
+deploy:
+  allowed_envs:
+    - staging
+    - production

--- a/tests/examples/completion_with_config/tasks.py
+++ b/tests/examples/completion_with_config/tasks.py
@@ -1,0 +1,144 @@
+"""
+Example showing tab completion callbacks that read from ToolkitConfig.
+
+This demonstrates the fix from v0.0.57: completion callbacks now receive a
+proper ToolkitContext backed by the program's already-loaded ToolkitConfig,
+so they can read project-level invoke.yaml values just like any regular task.
+
+Directory layout::
+
+    completion_with_config/
+    ├── tasks.py        # this file
+    └── invoke.yaml     # sets deploy.allowed_envs and completion.callback_timeout
+
+Try it::
+
+    # List available tasks
+    intk --search-root tests/examples/completion_with_config --list
+
+    # Tab-complete --target: suggestions filtered by deploy.allowed_envs from invoke.yaml
+    intk --search-root tests/examples/completion_with_config deploy --target <TAB>
+
+    # Tab-complete --env: only envs listed in deploy.allowed_envs are shown
+    intk --search-root tests/examples/completion_with_config deploy --env <TAB>
+
+    # Show which config values are in effect
+    intk --search-root tests/examples/completion_with_config show-config
+
+Edit invoke.yaml and change deploy.allowed_envs to see the completions change
+without touching this file.
+"""
+
+from textwrap import dedent
+from typing import Annotated
+
+from invoke_toolkit import Context, task
+
+# ---------------------------------------------------------------------------
+# Static data – all known targets, keyed by environment name
+# ---------------------------------------------------------------------------
+
+_ALL_TARGETS: dict[str, list[str]] = {
+    "dev": ["dev-us-east", "dev-eu-west"],
+    "staging": ["staging-us-east", "staging-us-west", "staging-eu-west"],
+    "production": ["prod-us-east", "prod-us-west", "prod-eu-west", "prod-ap-south"],
+}
+
+# ---------------------------------------------------------------------------
+# Completion callbacks
+# ---------------------------------------------------------------------------
+
+
+def complete_environments(ctx: Context, incomplete: str) -> list[str]:
+    """Return the environment names permitted by deploy.allowed_envs.
+
+    Reads ``deploy.allowed_envs`` from the project config (invoke.yaml).
+    When the key is absent every environment is offered.
+    """
+    allowed = ctx.get_config_value("deploy.allowed_envs", default=None)
+
+    if allowed:
+        envs = [e for e in allowed if e in _ALL_TARGETS]
+    else:
+        envs = list(_ALL_TARGETS.keys())
+
+    if incomplete:
+        envs = [e for e in envs if e.startswith(incomplete)]
+
+    return sorted(envs)
+
+
+def complete_targets(ctx: Context, incomplete: str) -> list[str]:
+    """Return deployment targets restricted to the allowed environments.
+
+    Reads ``deploy.allowed_envs`` from the project config (invoke.yaml) so
+    operators can narrow the suggestion list without touching task code.
+    """
+    allowed = ctx.get_config_value("deploy.allowed_envs", default=None)
+
+    if allowed:
+        candidates = [
+            t for env in allowed if env in _ALL_TARGETS for t in _ALL_TARGETS[env]
+        ]
+    else:
+        candidates = [t for targets in _ALL_TARGETS.values() for t in targets]
+
+    if incomplete:
+        candidates = [t for t in candidates if t.startswith(incomplete)]
+
+    return sorted(candidates)
+
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+
+@task
+def deploy(
+    ctx: Context,
+    target: Annotated[str, complete_targets] = "",
+    env: Annotated[str, complete_environments] = "dev",
+) -> None:
+    """Deploy to a target host.
+
+    Tab-complete ``--target`` to see hosts filtered by the environments listed
+    in ``deploy.allowed_envs`` (invoke.yaml).
+    Tab-complete ``--env`` to see the allowed environment names.
+
+    Args:
+        target: Deployment host (tab-complete to see available targets).
+        env: Environment name (tab-complete to see choices).
+    """
+    if not target:
+        ctx.rich_exit(
+            dedent(
+                """\
+                [red]No target specified.[/red]
+                Run with tab-completion or pass [cyan]--target <host>[/cyan].
+                """
+            )
+        )
+
+    ctx.print(f"[bold]Deploying[/bold] to [cyan]{target}[/cyan] (env: {env})")
+    ctx.run(f"echo 'deploy → {target}'")
+
+
+@task
+def show_config(ctx: Context) -> None:
+    """Show the config values that drive tab-completion in this example.
+
+    Run this to verify that your invoke.yaml overrides are being picked up.
+    """
+    timeout = ctx.get_config_value("completion.callback_timeout", default=10.0)
+    allowed = ctx.get_config_value("deploy.allowed_envs", default=None)
+
+    ctx.print("[bold]completion_with_config – effective settings[/bold]\n")
+    ctx.print(
+        dedent(
+            f"""\
+            completion.callback_timeout = [cyan]{timeout}[/cyan]
+            deploy.allowed_envs         = [cyan]{allowed or "<all>"}[/cyan]
+            """
+        )
+    )

--- a/tests/test_completion_with_choices.py
+++ b/tests/test_completion_with_choices.py
@@ -1170,3 +1170,205 @@ def test_completion_callback_has_access_to_config():
     assert "timeout=10.0" in choices, (
         f"Expected default timeout value (10.0) from ToolkitConfig, got: {choices}"
     )
+
+
+def test_completion_callback_reads_config_from_project_file(tmp_path):
+    """Test that completion callbacks read config values from a project config file.
+
+    When get_choices_for_argument receives an already-loaded config (as passed by
+    the program after load_project()), the callback must see the project-level
+    invoke.yaml values, not just the built-in defaults.
+    """
+    from invoke_toolkit.config import ToolkitConfig
+
+    # Write a project-level invoke.yaml that overrides the default timeout
+    config_file = tmp_path / "invoke.yaml"
+    config_file.write_text("completion:\n  callback_timeout: 42.0\n")
+
+    def config_aware_callback(ctx: Context, incomplete: str) -> list[str]:
+        """A callback that reports the configured timeout."""
+        timeout = ctx.get_config_value("completion.callback_timeout", default=999.0)
+        return [f"timeout={timeout}"]
+
+    coll = ToolkitCollection()
+
+    @task
+    def file_config_task(
+        ctx: Context,
+        option: Annotated[str, config_aware_callback],
+    ) -> None:
+        """Task whose callback reads config from a project file."""
+
+    coll.add_task(file_config_task)  # type: ignore[arg-type]
+
+    # Build the config exactly as the program does: set project location then merge
+    config = ToolkitConfig(project_location=tmp_path)
+    config.load_project()
+    config.merge()
+    assert config["completion"]["callback_timeout"] == 42.0, (
+        "Sanity check: invoke.yaml should override the default timeout"
+    )
+
+    # Pass the loaded config – the callback must now see 42.0, not 10.0 or 999.0
+    choices = get_choices_for_argument(
+        coll, "file-config-task", "option", "", config=config
+    )
+
+    assert len(choices) == 1, f"Expected 1 choice, got {len(choices)}: {choices}"
+    assert "timeout=42.0" in choices, (
+        f"Expected project-file value (42.0) from loaded config, got: {choices}"
+    )
+
+
+def test_completion_callback_without_config_uses_toolkit_defaults(tmp_path):
+    """Test that omitting config falls back to ToolkitConfig built-in defaults.
+
+    Callers that don't have a loaded config (e.g. direct unit tests) still get
+    sensible defaults rather than a bare invoke.Config.
+    """
+
+    # Write a project-level invoke.yaml – it must NOT affect the result here
+    config_file = tmp_path / "invoke.yaml"
+    config_file.write_text("completion:\n  callback_timeout: 42.0\n")
+
+    def config_aware_callback(ctx: Context, incomplete: str) -> list[str]:
+        timeout = ctx.get_config_value("completion.callback_timeout", default=999.0)
+        return [f"timeout={timeout}"]
+
+    coll = ToolkitCollection()
+
+    @task
+    def no_config_task(
+        ctx: Context,
+        option: Annotated[str, config_aware_callback],
+    ) -> None:
+        """Task whose callback is called without an explicit config."""
+
+    coll.add_task(no_config_task)  # type: ignore[arg-type]
+
+    # No config kwarg → fresh ToolkitConfig() → built-in default (10.0)
+    choices = get_choices_for_argument(coll, "no-config-task", "option", "")
+
+    assert len(choices) == 1, f"Expected 1 choice, got {len(choices)}: {choices}"
+    assert "timeout=10.0" in choices, (
+        f"Expected ToolkitConfig built-in default (10.0), got: {choices}"
+    )
+
+
+def test_completion_callback_project_config_via_program(tmp_path):
+    """End-to-end test: program loads invoke.yaml and passes config to completion.
+
+    Simulates the full program flow so we can verify that the config threaded
+    from parse_cleanup → complete_with_choices → get_choices_for_argument
+    makes project-level invoke.yaml values visible inside a callback.
+    """
+    # Write a tasks.py with a completion callback that reads a custom config key
+    tasks_file = tmp_path / "tasks.py"
+    tasks_file.write_text(
+        "from typing import Annotated\n"
+        "from invoke_toolkit import Context, task\n"
+        "\n"
+        "def complete_envs(ctx: Context, incomplete: str) -> list[str]:\n"
+        "    allowed = ctx.get_config_value('deploy.allowed_envs', default=None)\n"
+        "    if allowed:\n"
+        "        return [e for e in allowed if e.startswith(incomplete)]\n"
+        "    return ['fallback']\n"
+        "\n"
+        "@task\n"
+        "def deploy(ctx: Context, env: Annotated[str, complete_envs] = '') -> None:\n"
+        "    '''Deploy to an environment.'''\n"
+        "    ctx.print(env)\n"
+    )
+
+    # Write an invoke.yaml that sets a custom deploy.allowed_envs list
+    (tmp_path / "invoke.yaml").write_text(
+        "deploy:\n  allowed_envs:\n    - staging\n    - production\n"
+    )
+
+    argv = ["intk", "--complete", "--", "intk", "deploy", "--env", ""]
+    program = TestingToolkitProgram()
+    stdout_capture = io.StringIO()
+    with redirect_stdout(stdout_capture):
+        try:
+            program.run(argv, exit=False)
+        except (SystemExit, Exit):
+            pass
+
+    # The program is run from the project root, not tmp_path, so the invoke.yaml
+    # won't be picked up automatically.  Drive the search-root explicitly instead.
+    argv = [
+        "intk",
+        "--complete",
+        "--",
+        "intk",
+        "--search-root",
+        str(tmp_path),
+        "deploy",
+        "--env",
+        "",
+    ]
+    program = TestingToolkitProgram()
+    stdout_capture = io.StringIO()
+    with redirect_stdout(stdout_capture):
+        try:
+            program.run(argv, exit=False)
+        except (SystemExit, Exit):
+            pass
+
+    output = stdout_capture.getvalue()
+    assert "staging" in output, (
+        f"Expected 'staging' from invoke.yaml allowed_envs, got: {output!r}"
+    )
+    assert "production" in output, (
+        f"Expected 'production' from invoke.yaml allowed_envs, got: {output!r}"
+    )
+    assert "fallback" not in output, (
+        f"Expected project config to be used (not fallback), got: {output!r}"
+    )
+
+
+def test_completion_callback_config_not_base_invoke_config(tmp_path):
+    """Test that completion callbacks receive ToolkitConfig, not base invoke Config.
+
+    The key invariant restored by the fix: the ctx passed to a completion callback
+    must have a ToolkitConfig (which knows about the 'completion' key) rather than
+    a plain invoke.config.Config (which does not define that key and would raise or
+    return the fallback).
+    """
+
+    received_config_types = []
+
+    def type_checking_callback(ctx: Context, incomplete: str) -> list[str]:
+        """A callback that records the type of ctx.config."""
+        received_config_types.append(type(ctx.config).__name__)
+        # Also confirm the 'completion' section is accessible without raising
+        timeout = ctx.get_config_value("completion.callback_timeout", default=None)
+        return [f"config_type={type(ctx.config).__name__}", f"timeout={timeout}"]
+
+    coll = ToolkitCollection()
+
+    @task
+    def type_task(
+        ctx: Context,
+        option: Annotated[str, type_checking_callback],
+    ) -> None:
+        """Task whose callback inspects the config type."""
+
+    coll.add_task(type_task)  # type: ignore[arg-type]
+
+    choices = get_choices_for_argument(coll, "type-task", "option", "")
+
+    assert len(choices) == 2, f"Expected 2 choices, got {len(choices)}: {choices}"
+
+    # ctx.config must be a ToolkitConfig (or subclass), never a bare BaseConfig
+    config_type_choice = next(c for c in choices if c.startswith("config_type="))
+    assert "ToolkitConfig" in config_type_choice, (
+        f"Expected ToolkitConfig in callback, got: {config_type_choice}"
+    )
+
+    # The 'completion.callback_timeout' key must resolve to the default (10.0),
+    # not fall through to None (which would happen with bare BaseConfig)
+    timeout_choice = next(c for c in choices if c.startswith("timeout="))
+    assert timeout_choice == "timeout=10.0", (
+        f"Expected timeout=10.0 from ToolkitConfig defaults, got: {timeout_choice}"
+    )


### PR DESCRIPTION
## Summary

Extends the fix from PR #94 / issue #95. That PR correctly changed the context instantiation from `ToolkitContext()` to `ToolkitContext(config=ToolkitConfig())`, ensuring callbacks receive toolkit defaults. However, the config was still *freshly constructed* with no project location, so values from a project-level `invoke.yaml` were never visible inside a completion callback.

## Root Cause

`get_choices_for_argument()` always created a throwaway `ToolkitConfig()`. By the time completion runs, the program has already called `set_project_location()` + `load_project()` on `self.config` inside `load_collection()`. That fully-loaded config was never forwarded to the completion machinery.

## Changes

### `src/invoke_toolkit/completion.py`
- Added optional `config: ToolkitConfig | None = None` parameter to `complete_with_choices`, `_handle_flag_completion`, `_try_complete_flag_value`, `_handle_positional_completion`, and `get_choices_for_argument`.
- When provided, the `ToolkitContext` handed to each callback is backed by the caller's already-loaded config; falls back to `ToolkitConfig()` (previous behaviour) when omitted.

### `src/invoke_toolkit/program/program.py`
- `parse_cleanup` now passes `self.config` to `complete_with_choices`, making the full config hierarchy (system → user → project `invoke.yaml` → env vars) available to callbacks.

### `tests/test_completion_with_choices.py`
- Updated `test_completion_callback_reads_config_from_project_file`: now passes the loaded config and asserts the project-file value (`42.0`) is returned.
- Added `test_completion_callback_without_config_uses_toolkit_defaults`: ensures the no-config fallback still yields built-in defaults.
- Added `test_completion_callback_project_config_via_program`: end-to-end test through the full program flow with a real `invoke.yaml` on disk.

### `tests/examples/completion_with_config/`
New example demonstrating the feature:
- `tasks.py`: two completion callbacks that read `deploy.allowed_envs` from config to filter suggestions.
- `invoke.yaml`: sets `allowed_envs: [staging, production]` and `completion.callback_timeout`.
- `.gitignore`: un-ignores `invoke.yaml` inside this example directory.

## Verification

```
# Only staging + production targets shown (dev-* filtered out by invoke.yaml)
intk --search-root tests/examples/completion_with_config --complete -- intk deploy --target
```

Closes #95