### PR TITLE
feat: show command output below status spinner

### DIFF
--- a/src/invoke_toolkit/config/status_helper.py
+++ b/src/invoke_toolkit/config/status_helper.py
@@ -2,14 +2,21 @@
 Class that implements the ctx.status through the config class
 """
 
+from collections import deque
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator, Optional, Union
 
-from rich.console import Console, RenderableType
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.panel import Panel
+from rich.spinner import Spinner
 from rich.status import Status
 from rich.style import StyleType
+from rich.text import Text
 
 from invoke_toolkit.output import get_console
+
+MAX_OUTPUT_LINES = 3
 
 
 class NoOpStatus:
@@ -47,6 +54,95 @@ class NoOpStatus:
     def stop(self) -> None:
         """No-op stop"""
 
+    def capture_line(self, line: str) -> None:
+        """No-op capture"""
+
+
+class VerboseStatus:  # pylint: disable=too-many-instance-attributes
+    """Status that shows the last N lines of command output below the spinner."""
+
+    def __init__(
+        self,
+        status: RenderableType,
+        *,
+        console: Optional[Console] = None,
+        spinner: str = "dots",
+        spinner_style: StyleType = "status.spinner",
+        speed: float = 1.0,
+        refresh_per_second: float = 12.5,
+        max_lines: int = MAX_OUTPUT_LINES,
+    ):
+        self.status = status
+        self.spinner_style = spinner_style
+        self.speed = speed
+        self._lines: deque[str] = deque(maxlen=max_lines)
+        self._spinner = Spinner(spinner, text=status, style=spinner_style, speed=speed)
+        self._console = console or get_console()
+        self._live = Live(
+            self._build_renderable(),
+            console=self._console,
+            refresh_per_second=refresh_per_second,
+            transient=True,
+        )
+
+    def _build_renderable(self) -> RenderableType:
+        """Build the composite renderable: spinner + output panel."""
+        if not self._lines:
+            return self._spinner
+        output_text = Text("\n".join(self._lines), style="dim")
+        panel = Panel(
+            output_text,
+            border_style="dim",
+            padding=(0, 1),
+            expand=True,
+        )
+        return Group(self._spinner, panel)
+
+    def capture_line(self, line: str) -> None:
+        """Append a line of output and refresh the live display."""
+        self._lines.append(line.rstrip("\n\r"))
+        self._live.update(self._build_renderable())
+
+    def update(
+        self,
+        status: Optional[RenderableType] = None,
+        *,
+        spinner: Optional[str] = None,
+        spinner_style: Optional[StyleType] = None,
+        speed: Optional[float] = None,
+    ) -> None:
+        """Update the status text or spinner parameters."""
+        if status is not None:
+            self.status = status
+        if spinner_style is not None:
+            self.spinner_style = spinner_style
+        if speed is not None:
+            self.speed = speed
+        if spinner is not None:
+            self._spinner = Spinner(
+                spinner, text=self.status, style=self.spinner_style, speed=self.speed
+            )
+        else:
+            self._spinner.update(
+                text=self.status, style=self.spinner_style, speed=self.speed
+            )
+        self._live.update(self._build_renderable())
+
+    def start(self) -> None:
+        """Start the live display."""
+        self._live.start()
+
+    def stop(self) -> None:
+        """Stop the live display."""
+        self._live.stop()
+
+    def __enter__(self) -> "VerboseStatus":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
 
 class StatusHelper:
     """
@@ -54,13 +150,20 @@ class StatusHelper:
     it can be accessed from the task's context
     """
 
-    _current_status: Optional[Status]
+    _current_status: Optional[Union[Status, VerboseStatus]]
     _disabled: bool
+    _show_command_output: bool
 
-    def __init__(self, console: Console, disabled: bool = False):
+    def __init__(
+        self,
+        console: Console,
+        disabled: bool = False,
+        show_command_output: bool = False,
+    ):
         self.console = console or get_console()
         self._current_status = None
         self._disabled = disabled
+        self._show_command_output = show_command_output
 
     @contextmanager
     def status(
@@ -71,19 +174,31 @@ class StatusHelper:
         spinner_style: StyleType = "status.spinner",
         speed: float = 1.0,
         refresh_per_second: float = 12.5,
-    ) -> Generator[Status, None, None]:
+    ) -> Generator[Union[Status, VerboseStatus], None, None]:
         """Context manager for status management"""
         if self._disabled:
-            # When disabled, yield a no-op status object that prints messages
             with NoOpStatus(status=status, console=self.console) as noop:
-                yield noop
+                yield noop  # type: ignore[misc]
             return
 
         if self._current_status is not None:
+            # Nested status: update the existing one
             self._current_status.update(
                 status, spinner=spinner, spinner_style=spinner_style, speed=speed
             )
             yield self._current_status
+        elif self._show_command_output:
+            verbose = VerboseStatus(
+                status=status,
+                console=self.console,
+                spinner=spinner,
+                spinner_style=spinner_style,
+                speed=speed,
+                refresh_per_second=refresh_per_second,
+            )
+            with verbose as self._current_status:  # type: ignore[assignment]
+                yield self._current_status
+            self._current_status = None
         else:
             with self.console.status(
                 status=status,
@@ -94,6 +209,16 @@ class StatusHelper:
             ) as self._current_status:
                 yield self._current_status
             self._current_status = None
+
+    def capture_line(self, line: str) -> None:
+        """Feed a line of output to the current verbose status display."""
+        if isinstance(self._current_status, VerboseStatus):
+            self._current_status.capture_line(line)
+
+    @property
+    def is_verbose(self) -> bool:
+        """Whether the current status is a VerboseStatus."""
+        return isinstance(self._current_status, VerboseStatus)
 
     def status_update(
         self,

--- a/src/invoke_toolkit/context/context.py
+++ b/src/invoke_toolkit/context/context.py
@@ -75,10 +75,17 @@ class ToolkitContext(Context, ConfigProtocol):
         self._set("_console", get_console())
         # Check if status is disabled in the config
         disabled = False
+        show_command_output = False
         if config and hasattr(config, "get"):
             disabled = config.get("disable_status", False)
+            show_command_output = config.get("show_command_output", False)
         self._set(
-            "_status_helper", StatusHelper(console=self._console, disabled=disabled)
+            "_status_helper",
+            StatusHelper(
+                console=self._console,
+                disabled=disabled,
+                show_command_output=show_command_output,
+            ),
         )
 
     @property

--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -195,6 +195,11 @@ class ToolkitProgram(Program):
             debug("Disabling status context manager via CLI flag")
             self.config["disable_status"] = True  # type: ignore[index]
 
+        # Update config with show_command_output flag from CLI
+        if self.args["show_command_output"].value:
+            debug("Enabling command output display below status via CLI flag")
+            self.config["show_command_output"] = True  # type: ignore[index]
+
         # Update config with init_shell flag from CLI
         if self.args["init_shell"].value:
             debug("Initializing shell for runner via CLI flag")
@@ -340,6 +345,12 @@ class ToolkitProgram(Program):
                 kind=bool,
                 default=False,
                 help="Disables the rich status context manager for debugging (useful when debugging breakpoints or using REPL)",
+            ),
+            ToolkitArgument(
+                names=("show_command_output", "O"),
+                kind=bool,
+                default=False,
+                help="Shows last few lines of command output below the status spinner",
             ),
             ToolkitArgument(
                 names=("init_shell",),

--- a/src/invoke_toolkit/runners/rich.py
+++ b/src/invoke_toolkit/runners/rich.py
@@ -4,12 +4,16 @@ in tasks.
 """
 
 import sys
+from typing import TYPE_CHECKING, Optional
 
 from invoke.runners import Local
 from invoke.util import debug
 from rich.syntax import Syntax
 
 from invoke_toolkit.output import get_console
+
+if TYPE_CHECKING:
+    from invoke_toolkit.config.status_helper import StatusHelper
 
 
 class RedactingStream:
@@ -51,6 +55,46 @@ class RedactingStream:
         return getattr(self.original_stream, name)
 
 
+class OutputCapturingStream:
+    """A file-like wrapper that captures output lines and feeds them to a StatusHelper."""
+
+    def __init__(self, status_helper: "StatusHelper", original_stream):
+        self._status_helper = status_helper
+        self.original_stream = original_stream
+        self.encoding = getattr(original_stream, "encoding", "utf-8") or "utf-8"
+        self._buffer = ""
+
+    def write(self, text: str) -> int:
+        """Write text, splitting into lines for capture."""
+        if not text:
+            return 0
+
+        self._buffer += text
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            self._status_helper.capture_line(line)
+
+        return len(text)
+
+    def flush(self) -> None:
+        """Flush remaining buffer content."""
+        if self._buffer:
+            self._status_helper.capture_line(self._buffer)
+            self._buffer = ""
+        if hasattr(self.original_stream, "flush"):
+            self.original_stream.flush()
+
+    def isatty(self) -> bool:
+        """Return whether the underlying stream is a tty."""
+        if hasattr(self.original_stream, "isatty"):
+            return self.original_stream.isatty()
+        return False
+
+    def __getattr__(self, name):
+        """Delegate other attributes to the original stream."""
+        return getattr(self.original_stream, name)
+
+
 class NoStdoutRunner(Local):
     """Invoke runner that prints to stderr when invoke is used with -e/--echo
     and redacts secrets from subprocess output when redaction is enabled.
@@ -65,8 +109,13 @@ class NoStdoutRunner(Local):
             debug("context is missing print")
             print(self.opts["echo_format"].format(command=command), file=sys.stderr)
 
+    def _get_status_helper(self) -> "Optional[StatusHelper]":
+        if hasattr(self.context, "_status_helper"):
+            return self.context._status_helper  # pylint: disable=protected-access
+        return None
+
     def run(self, command, **kwargs):
-        """Execute command with redacting streams if redaction is enabled."""
+        """Execute command with redacting streams and optional output capture."""
         # Get the configured console objects
         out_console = get_console("out")
         err_console = get_console("err")
@@ -91,5 +140,16 @@ class NoStdoutRunner(Local):
             debug(
                 f"Running with redacting streams: {has_out_redaction=}, {has_err_redaction=}"
             )
+
+        # If we're inside a verbose status, capture output for the panel
+        status_helper = self._get_status_helper()
+        if status_helper and status_helper.is_verbose:
+            out_stream = kwargs.get("out_stream") or sys.stdout
+            err_stream = kwargs.get("err_stream") or sys.stderr
+            kwargs["out_stream"] = OutputCapturingStream(status_helper, out_stream)
+            kwargs["err_stream"] = OutputCapturingStream(status_helper, err_stream)
+            # Disable hide so output flows through our capturing stream
+            # (the stream feeds the Live panel instead of printing to terminal)
+            kwargs["hide"] = False
 
         return super().run(command, **kwargs)


### PR DESCRIPTION
## Summary

- Adds `--show-command-output` / `-O` CLI flag that displays the last 3 lines of subprocess output in a Rich Live panel below the status spinner
- When enabled, commands run inside `ctx.status()` show their output in real-time without breaking the spinner UX
- Output panel is transient (disappears when status completes), keeping terminal clean

Closes #103

## Implementation

- **`VerboseStatus`** class in `status_helper.py` — uses Rich `Live` + `Group` (spinner + Panel) to render status + output
- **`OutputCapturingStream`** in `runners/rich.py` — intercepts subprocess stdout/stderr line-by-line and feeds to the status panel
- **`NoStdoutRunner`** modified to detect verbose status and wire up capturing streams, overriding `hide` so output flows through
- **CLI flag** wired through `program.py` → config → `ToolkitContext` → `StatusHelper`

## Test plan

- [x] `inv -O version` works correctly (spinner + output panel during SCM version computation)
- [x] `inv version` (without flag) behaves exactly as before
- [x] `inv --ds version` (disable status) still prints plaintext
- [x] Existing test suite passes (`pytest tests/test_disable_status_cli.py tests/test_context_class.py` — 17 tests)
- [x] Nested status blocks work correctly
- [x] `hide=True` commands still get output captured in the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)