### PR TITLE
ci: fix missing workflow permissions for CodeQL

### DIFF
--- a/.github/workflows/publish-releases.yaml
+++ b/.github/workflows/publish-releases.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -33,6 +36,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -16,6 +16,9 @@ on:
         description: "Next version"
         value: ${{ jobs.check-release.outputs.next-version }}
 
+permissions:
+  contents: read
+
 jobs:
   check-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the `actions/missing-workflow-permissions` GitHub Code Scanning alerts by explicitly setting the scope of the default `GITHUB_TOKEN` in all GitHub Actions workflows to `contents: read` by default. 

Jobs that require specific write access explicitly request it to adhere to the principle of least privilege.