### PR TITLE
feat!: compatibility with invoke 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Entries are generated automatically by [commitizen](https://commitizen-tools.github.io/commitizen/)
+on version bumps.
+
+---
+
+## Unreleased
+
+### Breaking Changes
+
+- **invoke 3.0.x compatibility** — minimum required invoke version bumped from
+  `>=2.2.1` to `>=3.0.3`. invoke 3.0 introduced a backwards-incompatible
+  change to `Call.make_context` (new required `core_parse_result` argument) and
+  a new `Context.remainder` attribute. The following internal components were
+  updated to match:
+
+  - `ToolkitCall.make_context` now accepts `core_parse_result: ParseResult`
+    and forwards `core_parse_result.remainder` into `ToolkitContext`.
+  - `ToolkitContext.__init__` now accepts `remainder: str = ""` and passes it
+    to `invoke.context.Context.__init__`, making `ctx.remainder` available
+    inside tasks for wrapper-task patterns (e.g. `c.run(f"docker … {c.remainder}")`).
+  - `ToolkitExecutor.__init__` now defaults `self.core` to `ParseResult()`
+    instead of `None`, matching upstream `Executor` behaviour and ensuring
+    `core_parse_result.remainder` is always safe to access.
+
+### What invoke 3.0 brings
+
+- `Context.remainder` — exposes the CLI parser's remainder string (text after
+  a standalone `--`) directly on the context object, enabling elegant
+  [wrapper tasks](https://docs.pyinvoke.org/en/latest/concepts/invoking-tasks.html#wrapper-tasks).
+- `run()` return type — `Result` instead of `Optional[Result]`; `disown=True`
+  now returns `Result(disowned=True)` instead of `None`.
+- `Promise` is now a subclass of `Result` and gains a `__repr__`.
+
+### References
+
+- invoke 3.0.0 changelog: <https://www.pyinvoke.org/changelog.html#3-0-0-2026-04-05>
+- Fabric reference fix: <https://github.com/fabric/fabric/commit/7fa309db9dd5dac69079c1fb83b6f579555f7d53>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "invoke>=2.2.1",
+    "invoke>=3.0.3",
     "rich>=13",
     "typing-extensions>=4.13.2",
     "appdirs",

--- a/src/invoke_toolkit/context/context.py
+++ b/src/invoke_toolkit/context/context.py
@@ -70,8 +70,10 @@ class ToolkitContext(Context, ConfigProtocol):
         [Union[PathLike[str], str]], _GeneratorContextManager[None, None, None]
     ]
 
-    def __init__(self, config: Optional[ToolkitConfig] = None) -> None:
-        super().__init__(config)
+    def __init__(
+        self, config: Optional[ToolkitConfig] = None, remainder: str = ""
+    ) -> None:
+        super().__init__(config, remainder=remainder)
         self._set("_console", get_console())
         # Check if status is disabled in the config
         disabled = False

--- a/src/invoke_toolkit/executor.py
+++ b/src/invoke_toolkit/executor.py
@@ -39,11 +39,16 @@ class ToolkitExecutor(Executor):
 
         :param core:
             An optional `.ParseResult` holding parsed core program arguments.
-            Defaults to ``None``.
+            Defaults to an empty `.ParseResult` if not given.
+
+        .. versionchanged:: invoke 3.0
+            ``self.core`` now defaults to ``ParseResult()`` instead of
+            ``None``, matching upstream ``Executor`` behaviour and ensuring
+            ``core_parse_result.remainder`` is always accessible.
         """
         self.collection = collection
         self.config = config if config is not None else ToolkitConfig()
-        self.core = core
+        self.core = core if core is not None else ParseResult()
 
     def execute(
         self, *tasks: Union[str, Tuple[str, Dict[str, Any]], ParserContext]
@@ -134,7 +139,7 @@ class ToolkitExecutor(Executor):
             # Get final context from the Call (which will know how to generate
             # an appropriate one; e.g. subclasses might use extra data from
             # being parameterized), handing in this config for use there.
-            context = call.make_context(config)  # type: ignore[attr-defined]
+            context = call.make_context(config, core_parse_result=self.core)  # type: ignore[attr-defined]
             args = (context, *call.args)  # type: ignore[attr-defined]
             result = call.task(*args, **call.kwargs)  # type: ignore[attr-defined]
             if autoprint:

--- a/src/invoke_toolkit/tasks/tasks.py
+++ b/src/invoke_toolkit/tasks/tasks.py
@@ -2,7 +2,7 @@
 Type annotated tasks and and overrides over invoke
 """
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements,duplicate-code
 
 import inspect
 import os
@@ -822,9 +822,16 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
 
 
 class ToolkitCall(Call):
-    def make_context(self, config):
-        """Generates the Context for the task"""
-        return ToolkitContext(config=config)
+    def make_context(self, config, core_parse_result=None):
+        """Generates the Context for the task.
+
+        .. versionchanged:: invoke 3.0
+            Added the ``core_parse_result`` parameter so that
+            ``Context.remainder`` is populated from the CLI parser's remainder
+            value (text after a standalone ``--``).
+        """
+        remainder = core_parse_result.remainder if core_parse_result is not None else ""
+        return ToolkitContext(config=config, remainder=remainder)
 
 
 def call(task_: "Task", *args: Any, **kwargs: Any) -> "Call":

--- a/tests/test_invoke_3_compat.py
+++ b/tests/test_invoke_3_compat.py
@@ -1,0 +1,184 @@
+"""
+Tests for invoke 3.0.x compatibility.
+
+invoke 3.0 introduced two related breaking changes that affect invoke-toolkit:
+
+1. ``Call.make_context`` now requires a second argument ``core_parse_result``
+   (a ``ParseResult`` instance) so that ``Context.remainder`` can be populated
+   from the CLI parser's remainder value (text after a standalone ``--``).
+
+2. ``Context.__init__`` now accepts a ``remainder`` keyword argument and stores
+   it as ``self.remainder``.
+
+These tests verify that:
+- ``ToolkitCall.make_context`` accepts ``core_parse_result`` and propagates
+  ``remainder`` into the resulting ``ToolkitContext``.
+- ``ToolkitContext`` exposes ``ctx.remainder`` correctly.
+- ``ToolkitExecutor`` never passes ``None`` as ``core_parse_result`` (it
+  defaults to an empty ``ParseResult()``).
+- End-to-end: a task can read ``ctx.remainder`` when invoked with ``-- extra``.
+"""
+
+from invoke.parser import ParseResult
+from invoke.tasks import Task
+
+from invoke_toolkit import Context, task
+from invoke_toolkit.collections import ToolkitCollection
+from invoke_toolkit.config import ToolkitConfig
+from invoke_toolkit.context.context import ToolkitContext
+from invoke_toolkit.executor import ToolkitExecutor
+from invoke_toolkit.tasks.tasks import ToolkitCall
+
+
+# ---------------------------------------------------------------------------
+# Unit: ToolkitCall.make_context
+# ---------------------------------------------------------------------------
+
+
+def _dummy_task_func(ctx: Context) -> None:  # pragma: no cover
+    """Minimal real task used as a ToolkitCall target in unit tests."""
+
+
+_DUMMY_TASK: Task = task(_dummy_task_func)  # type: ignore[assignment]
+
+
+def _make_parse_result(remainder: str = "") -> ParseResult:
+    """Return a ParseResult whose .remainder is set to *remainder*."""
+    pr = ParseResult()
+    pr.remainder = remainder
+    return pr
+
+
+def test_make_context_without_core_parse_result():
+    """make_context(config) with no core_parse_result → remainder defaults to ''."""
+    config = ToolkitConfig()
+    c = ToolkitCall(_DUMMY_TASK)
+    ctx = c.make_context(config)
+    assert isinstance(ctx, ToolkitContext)
+    assert ctx.remainder == ""
+
+
+def test_make_context_with_empty_parse_result():
+    """make_context(config, core_parse_result=ParseResult()) → remainder is ''."""
+    config = ToolkitConfig()
+    c = ToolkitCall(_DUMMY_TASK)
+    ctx = c.make_context(config, core_parse_result=_make_parse_result(""))
+    assert isinstance(ctx, ToolkitContext)
+    assert ctx.remainder == ""
+
+
+def test_make_context_propagates_remainder():
+    """make_context passes ParseResult.remainder into ToolkitContext.remainder."""
+    config = ToolkitConfig()
+    c = ToolkitCall(_DUMMY_TASK)
+    ctx = c.make_context(config, core_parse_result=_make_parse_result("extra args"))
+    assert ctx.remainder == "extra args"
+
+
+def test_make_context_with_none_core_parse_result():
+    """Passing core_parse_result=None explicitly is safe (backward compat)."""
+    config = ToolkitConfig()
+    c = ToolkitCall(_DUMMY_TASK)
+    ctx = c.make_context(config, core_parse_result=None)
+    assert ctx.remainder == ""
+
+
+# ---------------------------------------------------------------------------
+# Unit: ToolkitContext.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_context_remainder_default():
+    """ToolkitContext() has remainder='' by default."""
+    ctx = ToolkitContext()
+    assert ctx.remainder == ""
+
+
+def test_toolkit_context_remainder_kwarg():
+    """ToolkitContext(remainder=...) stores the value on the instance."""
+    ctx = ToolkitContext(remainder="docker run --rm alpine")
+    assert ctx.remainder == "docker run --rm alpine"
+
+
+def test_toolkit_context_remainder_with_config():
+    """ToolkitContext(config=..., remainder=...) works with both args."""
+    config = ToolkitConfig()
+    ctx = ToolkitContext(config=config, remainder="--verbose")
+    assert ctx.remainder == "--verbose"
+
+
+# ---------------------------------------------------------------------------
+# Unit: ToolkitExecutor.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_executor_core_defaults_to_parse_result():
+    """ToolkitExecutor.core is never None; defaults to ParseResult()."""
+    col = ToolkitCollection()
+    executor = ToolkitExecutor(collection=col)
+    assert executor.core is not None
+    assert isinstance(executor.core, ParseResult)
+
+
+def test_executor_core_accepts_explicit_parse_result():
+    """ToolkitExecutor.core stores an explicitly provided ParseResult."""
+    col = ToolkitCollection()
+    pr = _make_parse_result("some remainder")
+    executor = ToolkitExecutor(collection=col, core=pr)
+    assert executor.core is pr
+    assert executor.core.remainder == "some remainder"
+
+
+def test_executor_core_none_becomes_empty_parse_result():
+    """Passing core=None explicitly still yields a ParseResult(), not None."""
+    col = ToolkitCollection()
+    executor = ToolkitExecutor(collection=col, core=None)
+    assert executor.core is not None
+    assert isinstance(executor.core, ParseResult)
+    assert executor.core.remainder == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration: ctx.remainder is accessible inside a task
+# ---------------------------------------------------------------------------
+
+
+def test_task_receives_remainder_via_context():
+    """A task can read ctx.remainder when the program is given a remainder."""
+    captured: list[str] = []
+
+    ns = ToolkitCollection()
+
+    @task  # type: ignore[arg-type]
+    def wrapper_task(ctx: Context):
+        """Wrapper task that captures ctx.remainder."""
+        captured.append(ctx.remainder)
+
+    ns.add_task(wrapper_task)  # type: ignore[arg-type]
+
+    pr = _make_parse_result("echo hello world")
+    config = ToolkitConfig()
+    executor = ToolkitExecutor(collection=ns, config=config, core=pr)
+    executor.execute("wrapper-task")
+
+    assert len(captured) == 1
+    assert captured[0] == "echo hello world"
+
+
+def test_task_remainder_empty_when_not_provided():
+    """ctx.remainder is '' when no remainder was parsed."""
+    captured: list[str] = []
+
+    ns = ToolkitCollection()
+
+    @task  # type: ignore[arg-type]
+    def simple_task(ctx: Context):
+        """Simple task that captures ctx.remainder."""
+        captured.append(ctx.remainder)
+
+    ns.add_task(simple_task)  # type: ignore[arg-type]
+
+    executor = ToolkitExecutor(collection=ns)
+    executor.execute("simple-task")
+
+    assert captured == [""]

--- a/uv.lock
+++ b/uv.lock
@@ -671,11 +671,11 @@ wheels = [
 
 [[package]]
 name = "invoke"
-version = "2.2.1"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hunter", marker = "extra == 'debug'", specifier = ">=3.7.0" },
     { name = "hunter", marker = "extra == 'full'", specifier = ">=3.7.0" },
-    { name = "invoke", specifier = ">=2.2.1" },
+    { name = "invoke", specifier = ">=3.0.3" },
     { name = "pdbpp", marker = "extra == 'debug'", specifier = ">=0.11.7" },
     { name = "pdbpp", marker = "extra == 'full'", specifier = ">=0.11.7" },
     { name = "platformdirs", specifier = ">=4.5.0" },


### PR DESCRIPTION
Closes #113

## What this PR does

Brings `invoke-toolkit` into compatibility with [invoke 3.0.3](https://github.com/pyinvoke/invoke/releases/tag/3.0.3), which introduced a backwards-incompatible change to `Call.make_context`.

---

## Breaking change in invoke 3.0

`Call.make_context` now requires a second argument `core_parse_result: ParseResult` so that `Context.remainder` can be populated from the CLI parser's remainder value (text after a standalone `--`). Without this fix, every task execution under invoke 3.x raises:

```
TypeError: ToolkitCall.make_context() got an unexpected keyword argument 'core_parse_result'
```

---

## Changes

### `src/invoke_toolkit/tasks/tasks.py`
`ToolkitCall.make_context` now accepts `core_parse_result=None` and extracts `.remainder` to pass into `ToolkitContext`. The `None` default keeps the signature backward-compatible.

### `src/invoke_toolkit/context/context.py`
`ToolkitContext.__init__` now accepts `remainder: str = ""` and forwards it to `super().__init__(config, remainder=remainder)`, wiring up invoke 3.0's new `ctx.remainder` attribute.

### `src/invoke_toolkit/executor.py`
- `self.core` defaults to `ParseResult()` instead of `None`, matching upstream invoke 3.0 behaviour.
- Call-site updated: `call.make_context(config)` → `call.make_context(config, core_parse_result=self.core)`.

### `pyproject.toml`
Dependency bumped: `invoke>=2.2.1` → `invoke>=3.0.3`.

### `tests/test_invoke_3_compat.py` (new, 12 tests)
Three layers of coverage:
- **Unit** — `ToolkitCall.make_context`: no arg, empty `ParseResult`, populated remainder, explicit `None`
- **Unit** — `ToolkitContext.__init__`: default, kwarg only, config + kwarg
- **Unit** — `ToolkitExecutor.__init__`: default, explicit `ParseResult`, explicit `None`
- **Integration** — 2 end-to-end tests running a real task through the executor and asserting `ctx.remainder` is correctly populated

### `CHANGELOG.md` (new)
Documents the invoke 3.x compatibility bump and what the new release brings.

---

## New capability unlocked

```python
@task
def docker(ctx: Context):
    """Run a command inside the project container."""
    ctx.run(f"docker compose run --rm app {ctx.remainder}")
```

```bash
inv docker -- pytest tests/ -x
#              ^^^^^^^^^^^^^^^^ ctx.remainder = "pytest tests/ -x"
```

---

## Test results

```
537 passed, 1 pre-existing failure (test_script_loads_project_config — pytest stdin/pty conflict, unrelated), 4 skipped
```