### PR TITLE
fix: warn and strip self-referential aliases to prevent RecursionError

### DIFF
--- a/src/invoke_toolkit/tasks/tasks.py
+++ b/src/invoke_toolkit/tasks/tasks.py
@@ -6,6 +6,7 @@ Type annotated tasks and and overrides over invoke
 
 import inspect
 import os
+import warnings
 import subprocess
 import types
 from enum import Enum
@@ -774,7 +775,22 @@ def task(  # pylint: disable=too-many-arguments,too-many-branches
         if name is not None:
             task_kwargs["name"] = name
         if aliases:
-            task_kwargs["aliases"] = aliases
+            # Normalize a name to invoke's canonical form (underscores → hyphens).
+            effective_name = (name or getattr(f, "__name__", "")).replace("_", "-")
+            filtered_aliases = [
+                a for a in aliases if a.replace("_", "-") != effective_name
+            ]
+            skipped = set(aliases) - set(filtered_aliases)
+            if skipped:
+                warnings.warn(
+                    f"Task '{effective_name}': alias(es) {sorted(skipped)!r} "
+                    "match the task name and will be ignored to prevent a "
+                    "RecursionError at runtime.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            if filtered_aliases:
+                task_kwargs["aliases"] = filtered_aliases
         if positional:
             task_kwargs["positional"] = positional
         if optional:

--- a/tests/test_alias_self_reference.py
+++ b/tests/test_alias_self_reference.py
@@ -1,0 +1,108 @@
+"""Tests for self-referential alias guard in @task."""
+
+import warnings
+
+import pytest
+from invoke import Collection
+
+from invoke_toolkit.tasks.tasks import task
+
+
+def _make_collection(*tasks):
+    c = Collection()
+    for t in tasks:
+        c.add_task(t)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Warning is emitted
+# ---------------------------------------------------------------------------
+
+
+def test_warns_when_alias_matches_function_name_underscore():
+    """Alias equal to the function name (underscore form) triggers a UserWarning."""
+    with pytest.warns(UserWarning, match="match the task name"):
+
+        @task(aliases=["my_task"])
+        def my_task(ctx):
+            pass
+
+
+def test_warns_when_alias_matches_function_name_hyphen():
+    """Alias equal to the hyphenated function name triggers a UserWarning."""
+    with pytest.warns(UserWarning, match="match the task name"):
+
+        @task(aliases=["my-task"])
+        def my_task(ctx):
+            pass
+
+
+def test_warns_when_alias_matches_explicit_name():
+    """Alias equal to an explicit name= override triggers a UserWarning."""
+    with pytest.warns(UserWarning, match="match the task name"):
+
+        @task(name="deploy", aliases=["deploy"])
+        def run_deploy(ctx):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Self-referential alias is stripped (no RecursionError)
+# ---------------------------------------------------------------------------
+
+
+def test_self_alias_stripped_task_is_reachable():
+    """After stripping the self-alias the task is still reachable by its name."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        @task(aliases=["my_task"])
+        def my_task(ctx):
+            pass
+
+    c = _make_collection(my_task)
+    # Must not raise RecursionError
+    resolved = c["my-task"]
+    assert resolved is not None
+
+
+def test_self_alias_stripped_valid_aliases_kept():
+    """Valid aliases are preserved; only the self-referential one is removed."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        @task(aliases=["my_task", "mt"])
+        def my_task(ctx):
+            pass
+
+    c = _make_collection(my_task)
+    assert c["mt"] is not None
+    assert c["my-task"] is not None
+
+
+def test_all_aliases_self_referential_no_aliases_registered():
+    """When every alias is self-referential the task has no aliases."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        @task(aliases=["my_task3"])
+        def my_task3(ctx):
+            pass
+
+    c = _make_collection(my_task3)
+    # task_names maps canonical name → list of aliases; list should be empty
+    assert c.task_names["my-task3"] == []
+
+
+def test_no_warning_for_distinct_alias():
+    """A genuinely distinct alias produces no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)  # would raise if a warning fires
+
+        @task(aliases=["mt"])
+        def my_task(ctx):
+            pass
+
+    c = _make_collection(my_task)
+    assert c["mt"] is not None


### PR DESCRIPTION
Fixes #115

## Problem

When a task alias normalises to the same name as the task itself (e.g. `@task(aliases=['my_task'])` on `def my_task`), invoke's internal `AliasDict` creates a self-referential pointer chain. Any lookup of that task hits Python's recursion limit:

```
RecursionError: maximum recursion depth exceeded
```

## Solution

Guard added in the `@task` decorator, just before aliases are forwarded to invoke:

1. Normalise each alias (`_` → `-`) and compare against the effective task name (`name=` param if given, otherwise `func.__name__`, also normalised).
2. Emit a `UserWarning` naming the offending alias(es).
3. Pass only the clean aliases to invoke; omit the key entirely if none remain.

```python
@task(aliases=["my_task", "mt"])  # "my_task" stripped, "mt" kept
def my_task(ctx): ...
# UserWarning: Task 'my-task': alias(es) ['my_task'] match the task name and will be ignored...
```

## Changes

- `src/invoke_toolkit/tasks/tasks.py` — alias guard + `import warnings`
- `tests/test_alias_self_reference.py` — 7 new tests

## Tests

| Test | Covers |
|------|--------|
| `test_warns_when_alias_matches_function_name_underscore` | Warning fires for underscore form |
| `test_warns_when_alias_matches_function_name_hyphen` | Warning fires for hyphen form |
| `test_warns_when_alias_matches_explicit_name` | Warning fires when `name=` is used |
| `test_self_alias_stripped_task_is_reachable` | No `RecursionError` after stripping |
| `test_self_alias_stripped_valid_aliases_kept` | Valid aliases alongside a bad one are preserved |
| `test_all_aliases_self_referential_no_aliases_registered` | All-bad case → empty alias list |
| `test_no_warning_for_distinct_alias` | No false-positive warning for a normal alias |