### PR TITLE
feat: add --list-tasks and --list-plugins filter flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ invoke.yaml
 # Makrdowns
 *.md
 !docs/**/*.md
+.worktrees/

--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -15,7 +15,7 @@ from importlib import metadata
 from importlib.util import module_from_spec
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 from rich.table import Table
 
@@ -81,6 +81,9 @@ class ToolkitProgram(Program):
             config_class,
             binary_names,
         )
+        # Names of sub-collections that were loaded from entry-point plugins.
+        # Populated in load_collection(); used by --list-tasks / --list-plugins.
+        self._plugin_collection_names: set[str] = set()
 
     def get_version(self) -> str:
         """Compute version
@@ -368,9 +371,91 @@ class ToolkitProgram(Program):
                 default=False,
                 help="Initializes shell for runner via CLI flag",
             ),
+            ToolkitArgument(
+                names=("list-tasks", "lt"),
+                kind=bool,
+                default=False,
+                help="List only the main tasks discovered in the current directory (excludes plugins)",
+            ),
+            ToolkitArgument(
+                names=("list-plugins", "lp"),
+                kind=bool,
+                default=False,
+                help="List only the plugin-provided task collections (excludes main tasks)",
+            ),
         ]
         args.extend(toolkit_program_arguments)
         return args
+
+    def _handle_list_flags(self) -> None:
+        """
+        Handle --list, --list-tasks, and --list-plugins flags.
+
+        Sets ``list_format`` / ``list_depth`` / ``scoped_collection`` as needed
+        and raises `Exit` when any listing flag is active.
+        """
+        self.list_format = self.args["list-format"].value
+        self.list_depth = self.args["list-depth"].value
+
+        # --list [root]: standard task listing (optionally scoped to a sub-collection)
+        list_root = self.args.list.value  # True or a string namespace
+        if list_root:
+            if isinstance(list_root, str):
+                self.list_root = list_root
+                try:
+                    sub = self.collection.subcollection_from_path(list_root)
+                    self.scoped_collection = sub
+                except KeyError:
+                    msg = "Sub-collection '{}' not found!"
+                    raise Exit(msg.format(list_root))
+            self.list_tasks()
+            raise Exit
+
+        # --list-tasks: show only main (non-plugin) tasks
+        if self.args["list-tasks"].value:
+            debug("Saw --list-tasks, listing main tasks only & exiting")
+            self.scoped_collection = self._make_filtered_collection("tasks")
+            self.list_tasks()
+            raise Exit
+
+        # --list-plugins: show only plugin-provided collections
+        if self.args["list-plugins"].value:
+            debug("Saw --list-plugins, listing plugin collections only & exiting")
+            if not self._plugin_collection_names:
+                raise Exit("No plugin collections found.")
+            self.scoped_collection = self._make_filtered_collection("plugins")
+            self.list_tasks()
+            raise Exit
+
+    def _make_filtered_collection(
+        self, mode: "Literal['tasks', 'plugins']"
+    ) -> "ToolkitCollection":
+        """
+        Return a shallow copy of ``self.scoped_collection`` containing only
+        the subset of tasks and sub-collections appropriate for *mode*.
+
+        - ``'tasks'``   – direct tasks + non-plugin sub-collections only
+        - ``'plugins'`` – plugin sub-collections only (no direct tasks)
+        """
+        source = self.scoped_collection
+        filtered = ToolkitCollection(source.name or "")
+        if mode == "tasks":
+            # Include all direct tasks on the scoped collection
+            for task_name, task in source.tasks.items():
+                filtered.add_task(task, name=task_name)
+            # Include sub-collections that are NOT from plugins
+            for coll_name, coll in source.collections.items():
+                if coll_name not in self._plugin_collection_names:
+                    filtered.add_collection(coll, name=coll_name)
+        else:  # mode == "plugins"
+            # Include only the plugin sub-collections
+            for coll_name, coll in source.collections.items():
+                if coll_name in self._plugin_collection_names:
+                    filtered.add_collection(coll, name=coll_name)
+        # Preserve the default task pointer when it still makes sense
+        if source.default and source.default in filtered.tasks:
+            filtered.default = source.default
+        return filtered
 
     def _load_entry_points_collection(self, start: str) -> "ToolkitCollection | None":
         """
@@ -453,6 +538,7 @@ class ToolkitProgram(Program):
                 debug("Merging entry point collections with tasks.py")
                 for name, collection in ep_collection.collections.items():
                     self.collection.add_collection(collection, name=name)
+                    self._plugin_collection_names.add(name)
         except CollectionNotFound as e:
             start = self.args["search-root"].value or "."
             # First try to load entry points (for packages without tasks.py)
@@ -460,6 +546,7 @@ class ToolkitProgram(Program):
             if ep_collection is not None:
                 debug("Loading collections from entry points")
                 self.collection = ep_collection
+                self._plugin_collection_names.update(ep_collection.collections.keys())
             else:
                 # If entry points weren't found, try local_tasks or fail
                 if not (Path(start) / "local_tasks.py").exists():
@@ -571,23 +658,8 @@ class ToolkitProgram(Program):
                 # should?
                 raise ParseError("No idea what '{}' is!".format(halp))
 
-        # Print discovered tasks if necessary
-        list_root = self.args.list.value  # will be True or string
-
-        self.list_format = self.args["list-format"].value
-        self.list_depth = self.args["list-depth"].value
-        if list_root:
-            # Not just --list, but --list some-root - do moar work
-            if isinstance(list_root, str):
-                self.list_root = list_root
-                try:
-                    sub = self.collection.subcollection_from_path(list_root)
-                    self.scoped_collection = sub
-                except KeyError:
-                    msg = "Sub-collection '{}' not found!"
-                    raise Exit(msg.format(list_root))
-            self.list_tasks()
-            raise Exit
+        # Handle --list / --list-tasks / --list-plugins (raises Exit if triggered)
+        self._handle_list_flags()
 
         # Print completion helpers if necessary
         if self.args.complete.value:

--- a/tests/test_list_filter_flags.py
+++ b/tests/test_list_filter_flags.py
@@ -1,0 +1,208 @@
+"""Tests for --list-tasks and --list-plugins filter flags."""
+
+import json
+
+
+from invoke_toolkit import Context, task
+from invoke_toolkit.collections import ToolkitCollection
+from invoke_toolkit.testing import TestingToolkitProgram
+
+
+# ---------------------------------------------------------------------------
+# Shared task/collection factories
+# ---------------------------------------------------------------------------
+
+
+@task()
+def main_task_a(ctx: Context):
+    """Main task A"""
+
+
+@task()
+def main_task_b(ctx: Context):
+    """Main task B"""
+
+
+@task()
+def plugin_task_x(ctx: Context):
+    """Plugin task X"""
+
+
+@task()
+def plugin_task_y(ctx: Context):
+    """Plugin task Y"""
+
+
+def _make_collection_with_plugins() -> tuple[ToolkitCollection, set[str]]:
+    """
+    Build a ToolkitCollection that looks like 'tasks.py + two plugin sub-collections'.
+    Returns the collection and the set of plugin sub-collection names.
+    """
+    coll = ToolkitCollection("root")
+    coll.add_task(main_task_a)
+    coll.add_task(main_task_b)
+
+    plugin_coll = ToolkitCollection("myplugin")
+    plugin_coll.add_task(plugin_task_x)
+    plugin_coll.add_task(plugin_task_y)
+    coll.add_collection(plugin_coll, name="myplugin")
+
+    another_plugin = ToolkitCollection("otherplugin")
+    coll.add_collection(another_plugin, name="otherplugin")
+
+    return coll, {"myplugin", "otherplugin"}
+
+
+def _program_with_plugins(
+    plugin_names: set[str] | None = None,
+) -> tuple[TestingToolkitProgram, ToolkitCollection]:
+    """Return a configured TestingToolkitProgram with a plugin-aware collection."""
+    coll, plugin_set = _make_collection_with_plugins()
+    p = TestingToolkitProgram(namespace=coll)
+    if plugin_names is None:
+        p._plugin_collection_names = plugin_set
+    else:
+        p._plugin_collection_names = plugin_names
+    return p, coll
+
+
+# ---------------------------------------------------------------------------
+# --list-tasks
+# ---------------------------------------------------------------------------
+
+
+def test_list_tasks_shows_main_tasks(capsys, suppress_stderr_logging):
+    """--list-tasks output contains the direct main tasks."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-tasks", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    task_names = {t["name"] for t in data["tasks"]}
+    assert "main-task-a" in task_names
+    assert "main-task-b" in task_names
+
+
+def test_list_tasks_excludes_plugin_collections(capsys, suppress_stderr_logging):
+    """--list-tasks must NOT include plugin sub-collections."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-tasks", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    coll_names = {c["name"] for c in data.get("collections", [])}
+    assert "myplugin" not in coll_names
+    assert "otherplugin" not in coll_names
+
+
+def test_list_tasks_flat_format(capsys, suppress_stderr_logging):
+    """--list-tasks works with the default flat format (no JSON)."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-tasks"])
+    out, _ = capsys.readouterr()
+    assert "main-task-a" in out
+    assert "main-task-b" in out
+    assert "myplugin" not in out
+
+
+def test_list_tasks_no_plugins_registered(capsys, suppress_stderr_logging):
+    """--list-tasks when there are no plugins still shows the main tasks."""
+    coll = ToolkitCollection("root")
+    coll.add_task(main_task_a)
+    p = TestingToolkitProgram(namespace=coll)
+    # _plugin_collection_names starts empty (no plugins)
+    p.run(["", "--list-tasks", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    task_names = {t["name"] for t in data["tasks"]}
+    assert "main-task-a" in task_names
+
+
+def test_list_tasks_preserves_non_plugin_subcollections(
+    capsys, suppress_stderr_logging
+):
+    """Non-plugin sub-collections (e.g. from tasks.py namespace) are kept by --list-tasks."""
+    coll = ToolkitCollection("root")
+    coll.add_task(main_task_a)
+
+    sub = ToolkitCollection("utils")
+    sub.add_task(main_task_b)
+    coll.add_collection(sub, name="utils")
+
+    plugin_coll = ToolkitCollection("myplugin")
+    plugin_coll.add_task(plugin_task_x)
+    coll.add_collection(plugin_coll, name="myplugin")
+
+    p = TestingToolkitProgram(namespace=coll)
+    p._plugin_collection_names = {"myplugin"}
+
+    p.run(["", "--list-tasks", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    coll_names = {c["name"] for c in data.get("collections", [])}
+    assert "utils" in coll_names
+    assert "myplugin" not in coll_names
+
+
+# ---------------------------------------------------------------------------
+# --list-plugins
+# ---------------------------------------------------------------------------
+
+
+def test_list_plugins_shows_plugin_collections(capsys, suppress_stderr_logging):
+    """--list-plugins output contains the plugin sub-collections."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-plugins", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    coll_names = {c["name"] for c in data.get("collections", [])}
+    assert "myplugin" in coll_names
+    assert "otherplugin" in coll_names
+
+
+def test_list_plugins_excludes_main_tasks(capsys, suppress_stderr_logging):
+    """--list-plugins must NOT include the direct main tasks."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-plugins", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    task_names = {t["name"] for t in data.get("tasks", [])}
+    assert "main-task-a" not in task_names
+    assert "main-task-b" not in task_names
+
+
+def test_list_plugins_flat_format(capsys, suppress_stderr_logging):
+    """--list-plugins works with the default flat format."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-plugins"])
+    out, _ = capsys.readouterr()
+    assert "myplugin" in out
+    assert "main-task-a" not in out
+
+
+def test_list_plugins_no_plugins_exits_with_message(capsys, suppress_stderr_logging):
+    """--list-plugins when there are no plugins exits with a clear message."""
+    coll = ToolkitCollection("root")
+    coll.add_task(main_task_a)
+    p = TestingToolkitProgram(namespace=coll)
+    # _plugin_collection_names is empty — no plugins loaded
+    p.run(["", "--list-plugins"])
+    # run(..., exit=False) so no sys.exit — just check stderr for the message
+    _, err = capsys.readouterr()
+    assert "No plugin collections found" in err
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion sanity (using both flags at once: first one wins)
+# ---------------------------------------------------------------------------
+
+
+def test_list_tasks_takes_precedence_over_list_plugins(capsys, suppress_stderr_logging):
+    """When both --list-tasks and --list-plugins are given, --list-tasks runs first."""
+    p, _ = _program_with_plugins()
+    p.run(["", "--list-tasks", "--list-plugins", "--list-format", "json"])
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    # Should behave like --list-tasks
+    task_names = {t["name"] for t in data["tasks"]}
+    assert "main-task-a" in task_names
+    coll_names = {c["name"] for c in data.get("collections", [])}
+    assert "myplugin" not in coll_names


### PR DESCRIPTION
Closes #119

## Summary

Adds two new filter flags for scoped task listing when a project has both local tasks and installed entry-point plugins.

| Flag | Short | Behaviour |
|---|---|---|
| `--list-tasks` | `-lt` | Main tasks only — excludes plugin sub-collections |
| `--list-plugins` | `-lp` | Plugin collections only — excludes main tasks. Exits cleanly with a message if no plugins are installed. |

Both flags respect `--list-format` (flat/nested/json) and `--list-depth`.

## Implementation

- **`_plugin_collection_names: set[str]`** — added to `ToolkitProgram.__init__`, populated in `load_collection()` at both entry-point merge sites (normal path + fallback-only-plugins path).
- **`_handle_list_flags()`** — new method consolidating `--list`, `--list-tasks`, and `--list-plugins` dispatch, extracted from `parse_cleanup()` to stay within pylint branch/statement limits.
- **`_make_filtered_collection(mode)`** — builds a shallow `ToolkitCollection` view (tasks or plugins) without mutating the real collection. Preserves the default task pointer when still applicable.

## Tests

10 new tests in `tests/test_list_filter_flags.py`:

- `--list-tasks` shows main tasks, excludes plugin collections (flat & JSON)
- `--list-tasks` with no plugins works gracefully
- `--list-tasks` preserves non-plugin sub-namespaces from `tasks.py`
- `--list-plugins` shows plugin collections, excludes main tasks (flat & JSON)
- `--list-plugins` with no plugins exits with a clear message
- Both flags together: `--list-tasks` takes precedence (checked first)