### PR TITLE
fix: address async task regressions

### DIFF
--- a/docs/async.qmd
+++ b/docs/async.qmd
@@ -1,0 +1,164 @@
+---
+title: "Async tasks"
+---
+
+Invoke Toolkit lets you write tasks as coroutines with `async def`. This is
+useful when a task spends most of its time waiting — on subprocesses, network
+calls, or other I/O — and you want to run several of those waits concurrently
+without threads.
+
+Async support is layered on top of Invoke. Synchronous tasks keep Invoke's
+normal blocking behaviour unchanged; the async machinery only engages when the
+requested task graph actually contains a coroutine task.
+
+## A first async task
+
+```{.python}
+from invoke_toolkit import Context, task
+
+
+@task
+async def build(ctx: Context):
+    result = await ctx.run("quarto render", hide=True)
+    await ctx.run_async("printf done")
+    return result
+```
+
+Run it exactly like any other task:
+
+```bash
+inv build
+```
+
+When Invoke Toolkit sees that `build` (or any of its pre/post tasks) is a
+coroutine function, it runs the whole invocation inside `asyncio.run(...)` and
+awaits each coroutine task's result.
+
+## How `ctx.run` behaves inside an async task
+
+Inside an `async def` task, `ctx.run(...)` returns an **awaitable** and uses a
+native `asyncio` subprocess under the hood:
+
+```{.python}
+@task
+async def check(ctx: Context):
+    result = await ctx.run("pytest -q", hide=True)   # awaitable here
+    return result.exited
+```
+
+`ctx.run_async(...)` is the explicit coroutine form and always returns an
+awaitable, regardless of context:
+
+```{.python}
+result = await ctx.run_async("pytest -q", hide=True)
+```
+
+In a **synchronous** task, `ctx.run(...)` is unchanged — it blocks and returns a
+`Result`, and Invoke's `asynchronous=True` promise API still works there.
+
+::: {.callout-important}
+## `await` your commands
+
+Because `ctx.run(...)` returns a coroutine inside an async task, forgetting the
+`await` means **the command never runs**. Python will emit
+`RuntimeWarning: coroutine 'ToolkitContext.run_async' was never awaited`, but the
+task otherwise appears to succeed. Treat that warning as an error.
+
+```{.python}
+@task
+async def deploy(ctx: Context):
+    ctx.run("terraform apply")          # BUG: never executes, no error raised
+    await ctx.run("terraform apply")    # correct
+```
+:::
+
+## Running commands concurrently with `ctx.gather()`
+
+`ctx.gather()` is an async context manager for launching several awaitables and
+collecting their results together. Submitted work starts **immediately**;
+`gather.results` is populated in submission order when the block exits:
+
+```{.python}
+@task
+async def fanout(ctx: Context):
+    async with ctx.gather() as gather:
+        gather(ctx.run_async("./slow-a.sh", hide=True))
+        gather(ctx.run_async("./slow-b.sh", hide=True))
+        gather(ctx.run_async("./slow-c.sh", hide=True))
+    return [r.stdout for r in gather.results]
+```
+
+Each `gather(...)` call returns the underlying `asyncio` task, so you can also
+await an individual one early. If any submitted awaitable raises, the remaining
+scheduled work is cancelled and the exception propagates out of the `async with`
+block.
+
+You can also use plain `asyncio` primitives — `asyncio.gather`,
+`asyncio.create_task`, `asyncio.TaskGroup` — with `ctx.run_async(...)`.
+`ctx.gather()` is just a small convenience wrapper that preserves submission
+order and cleans up on failure.
+
+## What the async command path supports
+
+`ctx.run_async` (and `ctx.run` inside an async task) replicates most of
+Invoke's `run` options:
+
+| Supported | Notes |
+|---|---|
+| `env`, `replace_env` | Same semantics as Invoke. |
+| `shell` | Defaults to `bash`. |
+| `encoding` | Defaults to Invoke's `default_encoding()`. |
+| `echo`, `echo_format` | Printed before execution, as with Invoke. |
+| `dry` | Returns a `Result` with `exited=0`; nothing runs. |
+| `warn` | Returns the failed `Result` instead of raising `UnexpectedExit`. |
+| `timeout` | Raises `CommandTimedOut` on expiry and terminates the process. |
+| `ctx.cd(...)`, `ctx.prefix(...)` | Honoured — the command is prefixed just like the sync path. |
+| Cancellation | Cancelling the awaiting task terminates the subprocess. |
+
+### What is **not** supported in the async path
+
+These raise a `ValueError`/`TypeError` when passed to `run_async`:
+
+- `pty=True` — no pseudo-terminal support.
+- `watchers=[...]` — no stream watchers / auto-responders.
+- `echo_stdin=True` and any interactive `in_stream` — stdin is wired to
+  `/dev/null`. Async commands are non-interactive.
+- `asynchronous=True` / `disown=True` — these are the sync runner's own
+  background modes and are rejected here.
+
+For any of those, call the synchronous `ctx.run(...)` from a synchronous task.
+
+::: {.callout-warning}
+## Known limitations and sharp edges
+
+The async support is functional but young. Be aware of the following in the
+current release:
+
+**Output is buffered, not streamed.** The async runner collects all output and
+writes it *after* the process exits. Long-running commands show no live/
+incremental output (no progress bars, no tailing), and very large output is
+held in memory. On timeout, output captured before the timeout is not returned.
+
+**Sync helper functions called from an async task have the same trap.** The
+"async context" is tracked with a `contextvars` flag that propagates into
+`asyncio.create_task(...)`. A plain synchronous helper you call from an async
+task that itself calls `ctx.run(...)` will get a coroutine it never awaits.
+Await commands directly in the async task, or make the helper `async` and
+`await` it.
+
+**`ctx.sudo(...)` does not work inside an async task.** `sudo` relies on a
+stream watcher to answer the password prompt, which the async path rejects. Use
+a synchronous task for `sudo`.
+
+:::
+
+## When to reach for async
+
+Use async tasks when the task is **I/O-bound** and you can overlap the waits —
+firing off several independent subprocesses, or awaiting several HTTP calls.
+For CPU-bound work, or when you need PTY/interactive/`sudo`/streaming behaviour,
+a synchronous task is the better fit.
+
+Task argument parsing, aliases, `--help`, enum/`Literal` validation, shell
+completion callbacks, and file-completion markers all work identically for async
+tasks — only the execution model changes.

--- a/src/invoke_toolkit/context/async_tools.py
+++ b/src/invoke_toolkit/context/async_tools.py
@@ -190,9 +190,9 @@ def _result(
 def _write_streams(result: Result, options: dict[str, Any]) -> None:
     out_stream = options.get("out_stream") or sys.stdout
     err_stream = options.get("err_stream") or sys.stderr
-    if "out" not in result.hide and out_stream is not False:
+    if "stdout" not in result.hide and out_stream is not False:
         out_stream.write(result.stdout)
         out_stream.flush()
-    if "err" not in result.hide and err_stream is not False:
+    if "stderr" not in result.hide and err_stream is not False:
         err_stream.write(result.stderr)
         err_stream.flush()

--- a/src/invoke_toolkit/context/context.py
+++ b/src/invoke_toolkit/context/context.py
@@ -8,6 +8,7 @@ from os import PathLike
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Generator,
     Iterator,
@@ -22,6 +23,7 @@ from typing import (
 
 import setproctitle
 from invoke.context import Context
+from invoke.runners import Result
 from invoke.util import debug
 from rich import inspect
 
@@ -29,7 +31,7 @@ from invoke_toolkit.config import ToolkitConfig
 from invoke_toolkit.config.status_helper import StatusHelper
 from invoke_toolkit.output.console import get_console
 
-from .types import AsyncContextRunProtocol, BoundPrintProtocol, ContextRunProtocol
+from .types import BoundPrintProtocol
 from .async_tools import AsyncGatherScope, in_async_task_context, run_async_command
 
 if TYPE_CHECKING:
@@ -61,8 +63,6 @@ class ConfigProtocol(Protocol):
 class ToolkitContext(Context, ConfigProtocol):
     """Type annotated override with async task support."""
 
-    run: ContextRunProtocol
-    run_async: AsyncContextRunProtocol
     _config: ToolkitConfig
     _status_helper: StatusHelper
 
@@ -96,14 +96,14 @@ class ToolkitContext(Context, ConfigProtocol):
         """A console instance to do rich output"""
         return get_console()
 
-    def run(self, command: str, **kwargs: Any):
-        """Run a command synchronously, or return a coroutine in async tasks."""
+    def run(self, command: str, **kwargs: Any) -> Result | Awaitable[Result]:
+        """Run a command or return an awaitable when called by an async task."""
         if in_async_task_context() and not kwargs.get("asynchronous", False):
             return self.run_async(command, **kwargs)
         runner = self.config.runners.local(self)
         return self._run(runner, command, **kwargs)
 
-    async def run_async(self, command: str, **kwargs: Any):
+    async def run_async(self, command: str, **kwargs: Any) -> Result:
         """Run a command without blocking the current asyncio event loop."""
         return await run_async_command(self, command, **kwargs)
 

--- a/src/invoke_toolkit/executor.py
+++ b/src/invoke_toolkit/executor.py
@@ -3,8 +3,9 @@ Custom executor class to for Syntax highlighted output
 """
 
 import inspect
+from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from invoke.executor import Executor
 from invoke.parser import ParserContext, ParseResult
@@ -73,7 +74,12 @@ class ToolkitExecutor(Executor):
             config.load_shell_env()
             context = call.make_context(config, core_parse_result=self.core)
             args = (context, *call.args)
-            with async_task_context():
+            context_manager = (
+                async_task_context()
+                if inspect.iscoroutinefunction(call.task.body)
+                else nullcontext()
+            )
+            with context_manager:
                 result = call.task(*args, **call.kwargs)
                 if inspect.isawaitable(result):
                     result = await result
@@ -181,6 +187,9 @@ class ToolkitExecutor(Executor):
         """
         ret = []
         for call in calls:
+            if isinstance(call, (list, tuple)):
+                ret.extend(self.expand_calls(cast(List[ToolkitCall], call)))
+                continue
             # Normalize to Call (this method is sometimes called with pre/post
             # task lists, which may contain 'raw' Task objects)
             if isinstance(call, Task):

--- a/src/invoke_toolkit/program/program.py
+++ b/src/invoke_toolkit/program/program.py
@@ -16,7 +16,7 @@ from importlib import import_module, metadata
 from importlib.util import module_from_spec
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, Union
 
 from rich.table import Table
 
@@ -56,6 +56,15 @@ from invoke_toolkit.loader.entrypoint import EntryPointLoader
 from invoke_toolkit.parser import ToolkitArgument
 
 EMPTY_COLLECTION_NAME = "_empty"
+
+
+def _task_bodies(items: Sequence[Any]) -> Iterator[Any]:
+    """Yield task bodies, recursively flattening grouped pre/post entries."""
+    for item in items:
+        if isinstance(item, (list, tuple)):
+            yield from _task_bodies(item)
+        elif hasattr(item, "body"):
+            yield item.body
 
 
 class ToolkitProgram(Program):
@@ -167,7 +176,7 @@ class ToolkitProgram(Program):
         for parser_context in self.tasks:
             task = self.collection[parser_context.name]
             calls = [task, *task.pre, *task.post]
-            if any(inspect.iscoroutinefunction(call.body) for call in calls):
+            if any(inspect.iscoroutinefunction(body) for body in _task_bodies(calls)):
                 return True
         default = self.collection.default
         return bool(

--- a/tests/test_async_support.py
+++ b/tests/test_async_support.py
@@ -1,8 +1,10 @@
 """Tests for native async task and command support."""
 
 import asyncio
+from typing import Awaitable, cast
 
 import pytest
+from invoke.runners import Result
 
 from invoke_toolkit import Context, task
 from invoke_toolkit.context import ToolkitContext
@@ -20,6 +22,19 @@ def test_run_async_returns_invoke_result():
         assert result.exited == 0
 
     asyncio.run(scenario())
+
+
+def test_run_async_hides_stdout_and_stderr(capsys):
+    async def scenario():
+        context = ToolkitContext()
+        result = await context.run_async("printf stdout; printf stderr >&2", hide=True)
+        assert result.stdout == "stdout"
+        assert result.stderr == "stderr"
+
+    asyncio.run(scenario())
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
 
 
 def test_run_async_warn_returns_failed_result():
@@ -68,7 +83,7 @@ def test_gather_scope_cancels_remaining_work():
 def test_async_task_runs_from_program(capsys):
     @task()
     async def async_task(ctx: Context):
-        result = await ctx.run("printf task", hide=True)
+        result = await cast(Awaitable[Result], ctx.run("printf task", hide=True))
         ctx.print(result.stdout)
         return result.exited
 
@@ -80,9 +95,45 @@ def test_async_task_runs_from_program(capsys):
 def test_sync_task_run_remains_synchronous():
     @task()
     def sync_task(ctx: Context):
-        result = ctx.run("printf sync", hide=True)
+        result = cast(Result, ctx.run("printf sync", hide=True))
         return result.stdout
 
     program = TestingToolkitProgram(namespace=ToolkitCollection(sync_task))
     program.run(["", "sync-task"], exit=False)
     assert sync_task.called
+
+
+def test_sync_pre_task_runs_blocking_command_in_async_invocation(tmp_path):
+    output = tmp_path / "pre-task-ran"
+
+    @task()
+    def sync_pre(ctx: Context):
+        ctx.run(f"printf ran > {output}", hide=True)
+
+    @task(pre=[sync_pre])
+    async def async_task(ctx: Context):
+        await cast(Awaitable[Result], ctx.run("true", hide=True))
+
+    program = TestingToolkitProgram(namespace=ToolkitCollection(async_task))
+    program.run(["", "async-task"], exit=False)
+    assert output.read_text() == "ran"
+
+
+def test_grouped_pre_tasks_do_not_crash_async_task_detection():
+    calls: list[str] = []
+
+    @task()
+    def pre_one(ctx: Context):
+        calls.append("pre-one")
+
+    @task()
+    def pre_two(ctx: Context):
+        calls.append("pre-two")
+
+    @task(pre=[[pre_one, pre_two]])  # type: ignore[arg-type]
+    def build(ctx: Context):
+        calls.append("build")
+
+    program = TestingToolkitProgram(namespace=ToolkitCollection(build))
+    program.run(["", "build"], exit=False)
+    assert calls == ["pre-one", "pre-two", "build"]


### PR DESCRIPTION
Closes #126

## Changes
- prevent async `hide=True` from writing captured stdout/stderr to the terminal
- preserve blocking `ctx.run()` semantics for synchronous tasks in async invocation graphs
- flatten grouped pre/post task entries for async detection and execution
- expose `ToolkitContext.run` as `Result | Awaitable[Result]` and document remaining async-path limits

## Verification
- `uv run pytest -q tests/test_async_support.py tests/test_async_edge_cases.py tests/test_grouped_tasks.py::test_grouped_async_pre_tasks_complete_before_following_pre_task`
- `uv run ruff check src/invoke_toolkit/context/async_tools.py src/invoke_toolkit/context/context.py src/invoke_toolkit/executor.py src/invoke_toolkit/program/program.py tests/test_async_support.py`
- `uv run ty check src/invoke_toolkit/context/context.py src/invoke_toolkit/executor.py tests/test_async_support.py`