### PR TITLE
ci: harden GitHub Actions supply chain

### DIFF
--- a/.github/workflows/publish-releases.yaml
+++ b/.github/workflows/publish-releases.yaml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.4.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
@@ -39,16 +39,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.4.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
@@ -56,6 +56,6 @@ jobs:
         run: uvx --with uv-dynamic-versioning hatchling build -d ./dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           attestations: true

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -29,7 +29,7 @@ jobs:
       next-version: ${{ steps.version.outputs.next-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -48,36 +48,38 @@ jobs:
           fi
 
           if [[ "$MESSAGE" == *"[release major]"* ]] || [[ "$MESSAGE" == *"[bump major]"* ]]; then
-            echo "should-release=true" >> $GITHUB_OUTPUT
-            echo "bump-type=major" >> $GITHUB_OUTPUT
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "bump-type=major" >> "$GITHUB_OUTPUT"
           elif [[ "$MESSAGE" == *"[release minor]"* ]] || [[ "$MESSAGE" == *"[bump minor]"* ]]; then
-            echo "should-release=true" >> $GITHUB_OUTPUT
-            echo "bump-type=minor" >> $GITHUB_OUTPUT
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "bump-type=minor" >> "$GITHUB_OUTPUT"
           elif [[ "$MESSAGE" == *"[release patch]"* ]] || [[ "$MESSAGE" == *"[bump patch]"* ]]; then
-            echo "should-release=true" >> $GITHUB_OUTPUT
-            echo "bump-type=patch" >> $GITHUB_OUTPUT
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "bump-type=patch" >> "$GITHUB_OUTPUT"
           else
-            echo "should-release=false" >> $GITHUB_OUTPUT
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get version from latest tag
         id: version
         if: steps.check.outputs.should-release == 'true'
+        env:
+          BUMP_TYPE: ${{ steps.check.outputs.bump-type }}
         run: |
           CURRENT=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
-          echo "current-version=$CURRENT" >> $GITHUB_OUTPUT
+          echo "current-version=$CURRENT" >> "$GITHUB_OUTPUT"
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
-          if [[ "${{ steps.check.outputs.bump-type }}" == "major" ]]; then
+          if [[ "$BUMP_TYPE" == "major" ]]; then
             NEXT="$((MAJOR + 1)).0.0"
-          elif [[ "${{ steps.check.outputs.bump-type }}" == "minor" ]]; then
+          elif [[ "$BUMP_TYPE" == "minor" ]]; then
             NEXT="$MAJOR.$((MINOR + 1)).0"
           else
             NEXT="$MAJOR.$MINOR.$((PATCH + 1))"
           fi
 
-          echo "next-version=$NEXT" >> $GITHUB_OUTPUT
+          echo "next-version=$NEXT" >> "$GITHUB_OUTPUT"
 
   create-release:
     needs: check-release
@@ -88,7 +90,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -98,21 +100,23 @@ jobs:
           git config --global user.name "github-actions[bot]"
 
       - name: Generate Release Notes
-        id: release-notes
         env:
+          BUMP_TYPE: ${{ needs.check-release.outputs.bump-type }}
           CURRENT_VERSION: ${{ needs.check-release.outputs.current-version }}
+          NEXT_VERSION: ${{ needs.check-release.outputs.next-version }}
         run: |
-          if [ "${{ needs.check-release.outputs.current-version }}" = "0.0.0" ]; then
+          if [ "$CURRENT_VERSION" = "0.0.0" ]; then
             COMMITS=$(git log --pretty=format:"%h - %s (%an)" HEAD)
           else
-            COMMITS=$(git log "v${{ needs.check-release.outputs.current-version }}..HEAD" --pretty=format:"%h - %s (%an)")
+            COMMITS=$(git log "v${CURRENT_VERSION}..HEAD" --pretty=format:"%h - %s (%an)")
           fi
 
-          # Use delimiter for multiline output
-          COMMITS_ESCAPED=$(echo "$COMMITS" | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' -e 's/"/\\"/g')
-          echo "commits<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            printf 'Automated release: %s bump\n\n' "$BUMP_TYPE"
+            printf 'Previous version: %s\n' "$CURRENT_VERSION"
+            printf 'New version: %s\n\n' "$NEXT_VERSION"
+            printf '## Changes\n\n%s\n' "$COMMITS"
+          } > release-notes.md
 
       - name: Create Release Tag
         env:
@@ -122,20 +126,11 @@ jobs:
           git push origin "v${NEXT_VERSION}"
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ needs.check-release.outputs.next-version }}
-          release_name: Release v${{ needs.check-release.outputs.next-version }}
-          body: |
-            Automated release: ${{ needs.check-release.outputs.bump-type }} bump
-
-            Previous version: ${{ needs.check-release.outputs.current-version }}
-            New version: ${{ needs.check-release.outputs.next-version }}
-
-            ## Changes
-
-            ${{ steps.release-notes.outputs.commits }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ github.token }}
+          NEXT_VERSION: ${{ needs.check-release.outputs.next-version }}
+        run: |
+          gh release create "v${NEXT_VERSION}" \
+            --verify-tag \
+            --title "Release v${NEXT_VERSION}" \
+            --notes-file release-notes.md

--- a/.github/workflows/test-release-and-publish.yaml
+++ b/.github/workflows/test-release-and-publish.yaml
@@ -28,16 +28,16 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: v${{ needs.release.outputs.next-version }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.4.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 
@@ -45,6 +45,6 @@ jobs:
         run: uvx --with uv-dynamic-versioning hatchling build -d ./dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           attestations: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.4.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Summary

- pin all 10 third-party GitHub Actions to reviewed immutable commit SHAs
- replace archived `actions/create-release@v1` with `gh release create --verify-tag`
- preserve release title and notes while moving GitHub expressions out of shell scripts

Closes #129

## Verification

- `actionlint -config-file .github/actionlint-config.yaml .github/workflows/*.yaml`
- workflow YAML parsing with PyYAML
- invariant check: 10 SHA-pinned action references; archived action removed; release tag verification enabled
- `uv run nox` — 665 passed, 23 skipped across Python 3.11–3.14

`zizmor` confirms no `unpinned-uses` or `archived-uses` findings remain. Its unrelated pre-existing findings (credential persistence, cache-poisoning, and excessive workflow-level permissions) remain outside this issue scope.