### PR TITLE
fix: prefer main local task namespace

### DIFF
--- a/src/invoke_toolkit/collections.py
+++ b/src/invoke_toolkit/collections.py
@@ -250,6 +250,13 @@ class ToolkitCollection(Collection):
         if not local_tasks_file.exists():
             debug(f"No local_tasks.py found at {local_tasks_file}")
             return
+        if "local" in self.tasks:
+            logger.warning(
+                "Skipping local_tasks.py at %s because tasks.py already defines "
+                "the 'local' task namespace",
+                local_tasks_file,
+            )
+            return
 
         debug(f"Loading local tasks from {local_tasks_file}")
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,10 +1,13 @@
 import ast
+import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
+from typing import Any, cast
 
+from invoke_toolkit import Task, task
 from invoke_toolkit.collections import ToolkitCollection
 
 
@@ -214,6 +217,27 @@ def test_load_local_tasks_without_main_tasks(tmp_path: Path):
 
     # Verify task is in the local collection
     assert "standalone-task" in local_col.tasks
+
+
+def test_load_local_tasks_preserves_conflicting_main_task(tmp_path: Path, caplog):
+    """A main task named local takes precedence over local_tasks.py."""
+
+    def main_task(ctx):
+        pass
+
+    decorated_main_task = cast(Task[Any], task()(main_task))
+    ns = ToolkitCollection()
+    ns.add_task(decorated_main_task, aliases=("local",))
+    (tmp_path / "local_tasks.py").write_text(
+        "from invoke_toolkit import task\n\n@task()\ndef local_task(ctx):\n    pass\n"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="invoke"):
+        ns.load_local_tasks(search_path=tmp_path)
+
+    assert ns.tasks["local"] is decorated_main_task
+    assert "local" not in ns.collections
+    assert "Skipping local_tasks.py" in caplog.text
 
 
 def test_load_local_tasks_from_multiple_directories_without_module_collision(


### PR DESCRIPTION
## Summary

- warn and skip `local_tasks.py` when the primary collection already owns the `local` task namespace
- preserve the primary task or alias so task discovery completes
- add regression coverage for the alias collision

Closes #132

## Verification

- `uv run pytest` — 726 passed, 18 skipped
- `uv run ruff check src/invoke_toolkit/collections.py tests/test_collection.py`
- `uv run ty check tests/test_collection.py`
- reproduced `intk -l` in datascape: warning emitted and `deploy-local (local)` remains available